### PR TITLE
Fix #5 - better error message for missing tokens

### DIFF
--- a/src/Microsoft.AspNet.Antiforgery/DefaultAntiforgeryTokenGenerator.cs
+++ b/src/Microsoft.AspNet.Antiforgery/DefaultAntiforgeryTokenGenerator.cs
@@ -6,22 +6,18 @@ using System.Diagnostics;
 using System.Security.Claims;
 using System.Security.Principal;
 using Microsoft.AspNet.Http;
-using Microsoft.Framework.OptionsModel;
 
 namespace Microsoft.AspNet.Antiforgery
 {
     public class DefaultAntiforgeryTokenGenerator : IAntiforgeryTokenGenerator
     {
         private readonly IClaimUidExtractor _claimUidExtractor;
-        private readonly AntiforgeryOptions _options;
         private readonly IAntiforgeryAdditionalDataProvider _additionalDataProvider;
 
         public DefaultAntiforgeryTokenGenerator(
-            IOptions<AntiforgeryOptions> optionsAccessor,
             IClaimUidExtractor claimUidExtractor,
             IAntiforgeryAdditionalDataProvider additionalDataProvider)
         {
-            _options = optionsAccessor.Options;
             _claimUidExtractor = claimUidExtractor;
             _additionalDataProvider = additionalDataProvider;
         }
@@ -96,23 +92,24 @@ namespace Microsoft.AspNet.Antiforgery
             AntiforgeryToken sessionToken,
             AntiforgeryToken fieldToken)
         {
-            // Were the tokens even present at all?
             if (sessionToken == null)
             {
-                throw new InvalidOperationException(
-                    Resources.FormatAntiforgeryToken_CookieMissing(_options.CookieName));
+                throw new ArgumentNullException(
+                    nameof(sessionToken),
+                    Resources.Antiforgery_CookieToken_MustBeProvided_Generic);
             }
+
             if (fieldToken == null)
             {
-                throw new InvalidOperationException(
-                    Resources.FormatAntiforgeryToken_FormFieldMissing(_options.FormFieldName));
+                throw new ArgumentNullException(
+                    nameof(fieldToken),
+                    Resources.Antiforgery_FormToken_MustBeProvided_Generic);
             }
 
             // Do the tokens have the correct format?
             if (!sessionToken.IsSessionToken || fieldToken.IsSessionToken)
             {
-                throw new InvalidOperationException(
-                    Resources.FormatAntiforgeryToken_TokensSwapped(_options.CookieName, _options.FormFieldName));
+                throw new InvalidOperationException(Resources.AntiforgeryToken_TokensSwapped);
             }
 
             // Are the security tokens embedded in each incoming token identical?

--- a/src/Microsoft.AspNet.Antiforgery/IAntiforgeryTokenGenerator.cs
+++ b/src/Microsoft.AspNet.Antiforgery/IAntiforgeryTokenGenerator.cs
@@ -1,8 +1,8 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System.Security.Claims;
 using Microsoft.AspNet.Http;
+using Microsoft.Framework.Internal;
 
 namespace Microsoft.AspNet.Antiforgery
 {
@@ -17,7 +17,7 @@ namespace Microsoft.AspNet.Antiforgery
         // Given a cookie token, generates a corresponding form token.
         // The incoming cookie token must be valid.
         AntiforgeryToken GenerateFormToken(
-            HttpContext httpContext,
+            [NotNull] HttpContext httpContext,
             AntiforgeryToken cookieToken);
 
         // Determines whether an existing cookie token is valid (well-formed).
@@ -26,8 +26,8 @@ namespace Microsoft.AspNet.Antiforgery
 
         // Validates a (cookie, form) token pair.
         void ValidateTokens(
-            HttpContext httpContext,
-            AntiforgeryToken cookieToken,
-            AntiforgeryToken formToken);
+            [NotNull] HttpContext httpContext,
+            [NotNull] AntiforgeryToken cookieToken,
+            [NotNull] AntiforgeryToken formToken);
     }
 }

--- a/src/Microsoft.AspNet.Antiforgery/IAntiforgeryTokenStore.cs
+++ b/src/Microsoft.AspNet.Antiforgery/IAntiforgeryTokenStore.cs
@@ -3,14 +3,23 @@
 
 using System.Threading.Tasks;
 using Microsoft.AspNet.Http;
+using Microsoft.Framework.Internal;
 
 namespace Microsoft.AspNet.Antiforgery
 {
     // Provides an abstraction around how tokens are persisted and retrieved for a request
     public interface IAntiforgeryTokenStore
     {
-        AntiforgeryToken GetCookieToken(HttpContext httpContext);
-        Task<AntiforgeryToken> GetFormTokenAsync(HttpContext httpContext);
-        void SaveCookieToken(HttpContext httpContext, AntiforgeryToken token);
+        AntiforgeryToken GetCookieToken([NotNull] HttpContext httpContext);
+
+        /// <summary>
+        /// Gets the cookie and form tokens from the request. Will throw an exception if either token is
+        /// not present.
+        /// </summary>
+        /// <param name="httpContext">The <see cref="HttpContext"/> for the current request.</param>
+        /// <returns>The <see cref="AntiforgeryTokenSet"/>.</returns>
+        Task<AntiforgeryTokenSet> GetRequestTokensAsync([NotNull] HttpContext httpContext);
+
+        void SaveCookieToken([NotNull] HttpContext httpContext, [NotNull] AntiforgeryToken token);
     }
 }

--- a/src/Microsoft.AspNet.Antiforgery/Properties/Resources.Designer.cs
+++ b/src/Microsoft.AspNet.Antiforgery/Properties/Resources.Designer.cs
@@ -59,22 +59,6 @@ namespace Microsoft.AspNet.Antiforgery
         }
 
         /// <summary>
-        /// The required antiforgery cookie "{0}" is not present.
-        /// </summary>
-        internal static string AntiforgeryToken_CookieMissing
-        {
-            get { return GetString("AntiforgeryToken_CookieMissing"); }
-        }
-
-        /// <summary>
-        /// The required antiforgery cookie "{0}" is not present.
-        /// </summary>
-        internal static string FormatAntiforgeryToken_CookieMissing(object p0)
-        {
-            return string.Format(CultureInfo.CurrentCulture, GetString("AntiforgeryToken_CookieMissing"), p0);
-        }
-
-        /// <summary>
         /// The antiforgery token could not be decrypted.
         /// </summary>
         internal static string AntiforgeryToken_DeserializationFailed
@@ -88,22 +72,6 @@ namespace Microsoft.AspNet.Antiforgery
         internal static string FormatAntiforgeryToken_DeserializationFailed()
         {
             return GetString("AntiforgeryToken_DeserializationFailed");
-        }
-
-        /// <summary>
-        /// The required antiforgery form field "{0}" is not present.
-        /// </summary>
-        internal static string AntiforgeryToken_FormFieldMissing
-        {
-            get { return GetString("AntiforgeryToken_FormFieldMissing"); }
-        }
-
-        /// <summary>
-        /// The required antiforgery form field "{0}" is not present.
-        /// </summary>
-        internal static string FormatAntiforgeryToken_FormFieldMissing(object p0)
-        {
-            return string.Format(CultureInfo.CurrentCulture, GetString("AntiforgeryToken_FormFieldMissing"), p0);
         }
 
         /// <summary>
@@ -123,7 +91,7 @@ namespace Microsoft.AspNet.Antiforgery
         }
 
         /// <summary>
-        /// Validation of the provided antiforgery token failed. The cookie "{0}" and the form field "{1}" were swapped.
+        /// Validation of the provided antiforgery token failed. The cookie token and the form token were swapped.
         /// </summary>
         internal static string AntiforgeryToken_TokensSwapped
         {
@@ -131,11 +99,11 @@ namespace Microsoft.AspNet.Antiforgery
         }
 
         /// <summary>
-        /// Validation of the provided antiforgery token failed. The cookie "{0}" and the form field "{1}" were swapped.
+        /// Validation of the provided antiforgery token failed. The cookie token and the form token were swapped.
         /// </summary>
-        internal static string FormatAntiforgeryToken_TokensSwapped(object p0, object p1)
+        internal static string FormatAntiforgeryToken_TokensSwapped()
         {
-            return string.Format(CultureInfo.CurrentCulture, GetString("AntiforgeryToken_TokensSwapped"), p0, p1);
+            return GetString("AntiforgeryToken_TokensSwapped");
         }
 
         /// <summary>
@@ -168,6 +136,70 @@ namespace Microsoft.AspNet.Antiforgery
         internal static string FormatAntiforgeryWorker_RequireSSL(object p0, object p1, object p2)
         {
             return string.Format(CultureInfo.CurrentCulture, GetString("AntiforgeryWorker_RequireSSL"), p0, p1, p2);
+        }
+
+        /// <summary>
+        /// The required antiforgery cookie "{0}" is not present.
+        /// </summary>
+        internal static string Antiforgery_CookieToken_MustBeProvided
+        {
+            get { return GetString("Antiforgery_CookieToken_MustBeProvided"); }
+        }
+
+        /// <summary>
+        /// The required antiforgery cookie "{0}" is not present.
+        /// </summary>
+        internal static string FormatAntiforgery_CookieToken_MustBeProvided(object p0)
+        {
+            return string.Format(CultureInfo.CurrentCulture, GetString("Antiforgery_CookieToken_MustBeProvided"), p0);
+        }
+
+        /// <summary>
+        /// The cookie token must be provided.
+        /// </summary>
+        internal static string Antiforgery_CookieToken_MustBeProvided_Generic
+        {
+            get { return GetString("Antiforgery_CookieToken_MustBeProvided_Generic"); }
+        }
+
+        /// <summary>
+        /// The cookie token must be provided.
+        /// </summary>
+        internal static string FormatAntiforgery_CookieToken_MustBeProvided_Generic()
+        {
+            return GetString("Antiforgery_CookieToken_MustBeProvided_Generic");
+        }
+
+        /// <summary>
+        /// The required antiforgery form field "{0}" is not present.
+        /// </summary>
+        internal static string Antiforgery_FormToken_MustBeProvided
+        {
+            get { return GetString("Antiforgery_FormToken_MustBeProvided"); }
+        }
+
+        /// <summary>
+        /// The required antiforgery form field "{0}" is not present.
+        /// </summary>
+        internal static string FormatAntiforgery_FormToken_MustBeProvided(object p0)
+        {
+            return string.Format(CultureInfo.CurrentCulture, GetString("Antiforgery_FormToken_MustBeProvided"), p0);
+        }
+
+        /// <summary>
+        /// The form token must be provided.
+        /// </summary>
+        internal static string Antiforgery_FormToken_MustBeProvided_Generic
+        {
+            get { return GetString("Antiforgery_FormToken_MustBeProvided_Generic"); }
+        }
+
+        /// <summary>
+        /// The form token must be provided.
+        /// </summary>
+        internal static string FormatAntiforgery_FormToken_MustBeProvided_Generic()
+        {
+            return GetString("Antiforgery_FormToken_MustBeProvided_Generic");
         }
 
         /// <summary>

--- a/src/Microsoft.AspNet.Antiforgery/Resources.resx
+++ b/src/Microsoft.AspNet.Antiforgery/Resources.resx
@@ -127,20 +127,14 @@
   <data name="AntiforgeryToken_ClaimUidMismatch" xml:space="preserve">
     <value>The provided antiforgery token was meant for a different claims-based user than the current user.</value>
   </data>
-  <data name="AntiforgeryToken_CookieMissing" xml:space="preserve">
-    <value>The required antiforgery cookie "{0}" is not present.</value>
-  </data>
   <data name="AntiforgeryToken_DeserializationFailed" xml:space="preserve">
     <value>The antiforgery token could not be decrypted.</value>
-  </data>
-  <data name="AntiforgeryToken_FormFieldMissing" xml:space="preserve">
-    <value>The required antiforgery form field "{0}" is not present.</value>
   </data>
   <data name="AntiforgeryToken_SecurityTokenMismatch" xml:space="preserve">
     <value>The antiforgery cookie token and form field token do not match.</value>
   </data>
   <data name="AntiforgeryToken_TokensSwapped" xml:space="preserve">
-    <value>Validation of the provided antiforgery token failed. The cookie "{0}" and the form field "{1}" were swapped.</value>
+    <value>Validation of the provided antiforgery token failed. The cookie token and the form token were swapped.</value>
   </data>
   <data name="AntiforgeryToken_UsernameMismatch" xml:space="preserve">
     <value>The provided antiforgery token was meant for user "{0}", but the current user is "{1}".</value>
@@ -148,6 +142,18 @@
   <data name="AntiforgeryWorker_RequireSSL" xml:space="preserve">
     <value>The antiforgery system has the configuration value {0}.{1} = {2}, but the current request is not an SSL request.</value>
     <comment>0 = nameof(AntiforgeryOptions), 1 = nameof(RequireSsl), 2 = bool.TrueString</comment>
+  </data>
+  <data name="Antiforgery_CookieToken_MustBeProvided" xml:space="preserve">
+    <value>The required antiforgery cookie "{0}" is not present.</value>
+  </data>
+  <data name="Antiforgery_CookieToken_MustBeProvided_Generic" xml:space="preserve">
+    <value>The cookie token must be provided.</value>
+  </data>
+  <data name="Antiforgery_FormToken_MustBeProvided" xml:space="preserve">
+    <value>The required antiforgery form field "{0}" is not present.</value>
+  </data>
+  <data name="Antiforgery_FormToken_MustBeProvided_Generic" xml:space="preserve">
+    <value>The form token must be provided.</value>
   </data>
   <data name="ArgumentCannotBeNullOrEmpty" xml:space="preserve">
     <value>Value cannot be null or empty.</value>

--- a/test/Microsoft.AspNet.Antiforgery.Test/DefaultAntiforgeryTokenGeneratorTest.cs
+++ b/test/Microsoft.AspNet.Antiforgery.Test/DefaultAntiforgeryTokenGeneratorTest.cs
@@ -19,7 +19,6 @@ namespace Microsoft.AspNet.Antiforgery
         {
             // Arrange
             var tokenProvider = new DefaultAntiforgeryTokenGenerator(
-                optionsAccessor: new TestOptionsManager(),
                 claimUidExtractor: null,
                 additionalDataProvider: null);
 
@@ -40,7 +39,6 @@ namespace Microsoft.AspNet.Antiforgery
             Assert.False(httpContext.User.Identity.IsAuthenticated);
 
             var tokenProvider = new DefaultAntiforgeryTokenGenerator(
-                optionsAccessor: new TestOptionsManager(),
                 claimUidExtractor: null,
                 additionalDataProvider: null);
 
@@ -74,7 +72,6 @@ namespace Microsoft.AspNet.Antiforgery
             var claimUidExtractor = new Mock<IClaimUidExtractor>().Object;
 
             var tokenProvider = new DefaultAntiforgeryTokenGenerator(
-                optionsAccessor: new TestOptionsManager(),
                 claimUidExtractor: claimUidExtractor,
                 additionalDataProvider: null);
 
@@ -109,7 +106,6 @@ namespace Microsoft.AspNet.Antiforgery
             var claimUidExtractor = new Mock<IClaimUidExtractor>().Object;
 
             var tokenProvider = new DefaultAntiforgeryTokenGenerator(
-                optionsAccessor: new TestOptionsManager(),
                 claimUidExtractor: claimUidExtractor,
                 additionalDataProvider: mockAdditionalDataProvider.Object);
 
@@ -148,7 +144,6 @@ namespace Microsoft.AspNet.Antiforgery
                                  .Returns(base64ClaimUId);
 
             var tokenProvider = new DefaultAntiforgeryTokenGenerator(
-                optionsAccessor: new TestOptionsManager(),
                 claimUidExtractor: mockClaimUidExtractor.Object,
                 additionalDataProvider: null);
 
@@ -182,7 +177,6 @@ namespace Microsoft.AspNet.Antiforgery
             var claimUidExtractor = new Mock<IClaimUidExtractor>().Object;
 
             var tokenProvider = new DefaultAntiforgeryTokenGenerator(
-                optionsAccessor: new TestOptionsManager(),
                 claimUidExtractor: claimUidExtractor,
                 additionalDataProvider: null);
 
@@ -209,7 +203,6 @@ namespace Microsoft.AspNet.Antiforgery
             };
 
             var tokenProvider = new DefaultAntiforgeryTokenGenerator(
-                optionsAccessor: new TestOptionsManager(),
                 claimUidExtractor: null,
                 additionalDataProvider: null);
 
@@ -226,7 +219,6 @@ namespace Microsoft.AspNet.Antiforgery
             // Arrange
             AntiforgeryToken cookieToken = null;
             var tokenProvider = new DefaultAntiforgeryTokenGenerator(
-                optionsAccessor: new TestOptionsManager(),
                 claimUidExtractor: null,
                 additionalDataProvider: null);
 
@@ -247,7 +239,6 @@ namespace Microsoft.AspNet.Antiforgery
             };
 
             var tokenProvider = new DefaultAntiforgeryTokenGenerator(
-                optionsAccessor: new TestOptionsManager(),
                 claimUidExtractor: null,
                 additionalDataProvider: null);
 
@@ -268,21 +259,16 @@ namespace Microsoft.AspNet.Antiforgery
 
             var fieldtoken = new AntiforgeryToken() { IsSessionToken = false };
 
-            var options = new AntiforgeryOptions()
-            {
-                CookieName = "my-cookie-name"
-            };
-
             var tokenProvider = new DefaultAntiforgeryTokenGenerator(
-                optionsAccessor: new TestOptionsManager(options),
                 claimUidExtractor: null,
                 additionalDataProvider: null);
 
             // Act & assert
-            var ex =
-                Assert.Throws<InvalidOperationException>(
-                    () => tokenProvider.ValidateTokens(httpContext, null, fieldtoken));
-            Assert.Equal(@"The required antiforgery cookie ""my-cookie-name"" is not present.", ex.Message);
+            var ex = Assert.Throws<ArgumentNullException>(
+                () => tokenProvider.ValidateTokens(httpContext, null, fieldtoken));
+
+            var trimmed = ex.Message.Substring(0, ex.Message.IndexOf(Environment.NewLine));
+            Assert.Equal(@"The cookie token must be provided.", trimmed);
         }
 
         [Fact]
@@ -294,21 +280,16 @@ namespace Microsoft.AspNet.Antiforgery
 
             var sessionToken = new AntiforgeryToken() { IsSessionToken = true };
 
-            var options = new AntiforgeryOptions()
-            {
-                FormFieldName = "my-form-field-name"
-            };
-
             var tokenProvider = new DefaultAntiforgeryTokenGenerator(
-                optionsAccessor: new TestOptionsManager(options),
                 claimUidExtractor: null,
                 additionalDataProvider: null);
 
             // Act & assert
-            var ex =
-                Assert.Throws<InvalidOperationException>(
-                    () => tokenProvider.ValidateTokens(httpContext, sessionToken, null));
-            Assert.Equal(@"The required antiforgery form field ""my-form-field-name"" is not present.", ex.Message);
+            var ex = Assert.Throws<ArgumentNullException>(
+                () => tokenProvider.ValidateTokens(httpContext, sessionToken, null));
+
+            var trimmed = ex.Message.Substring(0, ex.Message.IndexOf(Environment.NewLine));
+            Assert.Equal("The form token must be provided.", trimmed);
         }
 
         [Fact]
@@ -321,14 +302,7 @@ namespace Microsoft.AspNet.Antiforgery
             var sessionToken = new AntiforgeryToken() { IsSessionToken = true };
             var fieldtoken = new AntiforgeryToken() { IsSessionToken = false };
 
-            var options = new AntiforgeryOptions()
-            {
-                CookieName = "my-cookie-name",
-                FormFieldName = "my-form-field-name"
-            };
-
             var tokenProvider = new DefaultAntiforgeryTokenGenerator(
-                optionsAccessor: new TestOptionsManager(options),
                 claimUidExtractor: null,
                 additionalDataProvider: null);
 
@@ -338,7 +312,7 @@ namespace Microsoft.AspNet.Antiforgery
                     () => tokenProvider.ValidateTokens(httpContext, fieldtoken, fieldtoken));
             Assert.Equal(
                 "Validation of the provided antiforgery token failed. " +
-                @"The cookie ""my-cookie-name"" and the form field ""my-form-field-name"" were swapped.",
+                @"The cookie token and the form token were swapped.",
                 ex1.Message);
 
             var ex2 =
@@ -346,7 +320,7 @@ namespace Microsoft.AspNet.Antiforgery
                     () => tokenProvider.ValidateTokens(httpContext, sessionToken, sessionToken));
             Assert.Equal(
                 "Validation of the provided antiforgery token failed. " +
-                @"The cookie ""my-cookie-name"" and the form field ""my-form-field-name"" were swapped.",
+                @"The cookie token and the form token were swapped.",
                 ex2.Message);
         }
 
@@ -361,7 +335,6 @@ namespace Microsoft.AspNet.Antiforgery
             var fieldtoken = new AntiforgeryToken() { IsSessionToken = false };
 
             var tokenProvider = new DefaultAntiforgeryTokenGenerator(
-                optionsAccessor: new TestOptionsManager(),
                 claimUidExtractor: null,
                 additionalDataProvider: null);
 
@@ -399,7 +372,6 @@ namespace Microsoft.AspNet.Antiforgery
                                  .Returns((string)null);
 
             var tokenProvider = new DefaultAntiforgeryTokenGenerator(
-                optionsAccessor: new TestOptionsManager(),
                 claimUidExtractor: mockClaimUidExtractor.Object,
                 additionalDataProvider: null);
 
@@ -434,7 +406,6 @@ namespace Microsoft.AspNet.Antiforgery
                                  .Returns(Convert.ToBase64String(differentToken.GetData()));
 
             var tokenProvider = new DefaultAntiforgeryTokenGenerator(
-                optionsAccessor: new TestOptionsManager(),
                 claimUidExtractor: mockClaimUidExtractor.Object,
                 additionalDataProvider: null);
 
@@ -468,7 +439,6 @@ namespace Microsoft.AspNet.Antiforgery
                                       .Returns(false);
 
             var tokenProvider = new DefaultAntiforgeryTokenGenerator(
-                optionsAccessor: new TestOptionsManager(),
                 claimUidExtractor: null,
                 additionalDataProvider: mockAdditionalDataProvider.Object);
 
@@ -500,7 +470,6 @@ namespace Microsoft.AspNet.Antiforgery
                                       .Returns(true);
 
             var tokenProvider = new DefaultAntiforgeryTokenGenerator(
-                optionsAccessor: new TestOptionsManager(),
                 claimUidExtractor: null,
                 additionalDataProvider: mockAdditionalDataProvider.Object);
 
@@ -533,7 +502,6 @@ namespace Microsoft.AspNet.Antiforgery
                                       .Returns(true);
 
             var tokenProvider = new DefaultAntiforgeryTokenGenerator(
-                optionsAccessor: new TestOptionsManager(),
                 claimUidExtractor: new Mock<IClaimUidExtractor>().Object,
                 additionalDataProvider: mockAdditionalDataProvider.Object);
 
@@ -565,7 +533,6 @@ namespace Microsoft.AspNet.Antiforgery
                                  .Returns(Convert.ToBase64String(fieldtoken.ClaimUid.GetData()));
 
             var tokenProvider = new DefaultAntiforgeryTokenGenerator(
-                optionsAccessor: new TestOptionsManager(),
                 claimUidExtractor: mockClaimUidExtractor.Object,
                 additionalDataProvider: null);
 


### PR DESCRIPTION
This fix changes the model for error messaging in antiforgery. Now only
the token store will report a detailed error message including the names
of form field and cookie. Other components will give more generic errors
and assume that this was handled by the token store.

This way you still see an error if the user creates a token store that
doesn't throw, but it's a generic error that doesn't give incorrect
information.