### PR TITLE
Fix aspnet/Mvc#2749 - fail gracefully with non-form content

### DIFF
--- a/src/Microsoft.AspNet.Antiforgery/DefaultAntiforgeryTokenStore.cs
+++ b/src/Microsoft.AspNet.Antiforgery/DefaultAntiforgeryTokenStore.cs
@@ -53,6 +53,14 @@ namespace Microsoft.AspNet.Antiforgery
                     Resources.FormatAntiforgery_CookieToken_MustBeProvided(_options.CookieName));
             }
 
+            if (!httpContext.Request.HasFormContentType)
+            {
+                // Check the content-type before accessing the form collection to make sure
+                // we throw gracefully.
+                throw new InvalidOperationException(
+                    Resources.FormatAntiforgery_FormToken_MustBeProvided(_options.FormFieldName));
+            }
+
             var form = await httpContext.Request.ReadFormAsync();
             var formField = form[_options.FormFieldName];
             if (string.IsNullOrEmpty(formField))


### PR DESCRIPTION
This change will report a more specific error when antiforgery is used
with non-form content than "invalid content type".