### PR TITLE
Adds a IsRequestValidAsync method

### DIFF
--- a/src/Microsoft.AspNetCore.Antiforgery/DefaultAntiforgery.cs
+++ b/src/Microsoft.AspNetCore.Antiforgery/DefaultAntiforgery.cs
@@ -36,75 +36,100 @@ namespace Microsoft.AspNetCore.Antiforgery
         }
 
         /// <inheritdoc />
-        public IHtmlContent GetHtml(HttpContext context)
+        public IHtmlContent GetHtml(HttpContext httpContext)
         {
-            if (context == null)
+            if (httpContext == null)
             {
-                throw new ArgumentNullException(nameof(context));
+                throw new ArgumentNullException(nameof(httpContext));
             }
 
-            CheckSSLConfig(context);
+            CheckSSLConfig(httpContext);
 
-            var tokenSet = GetAndStoreTokens(context);
+            var tokenSet = GetAndStoreTokens(httpContext);
             return new InputContent(_options.FormFieldName, tokenSet.RequestToken);
         }
 
         /// <inheritdoc />
-        public AntiforgeryTokenSet GetAndStoreTokens(HttpContext context)
+        public AntiforgeryTokenSet GetAndStoreTokens(HttpContext httpContext)
         {
-            if (context == null)
+            if (httpContext == null)
             {
-                throw new ArgumentNullException(nameof(context));
+                throw new ArgumentNullException(nameof(httpContext));
             }
 
-            CheckSSLConfig(context);
+            CheckSSLConfig(httpContext);
 
-            var tokenSet = GetTokensInternal(context);
+            var tokenSet = GetTokensInternal(httpContext);
             if (tokenSet.IsNewCookieToken)
             {
-                SaveCookieTokenAndHeader(context, tokenSet.CookieToken);
+                SaveCookieTokenAndHeader(httpContext, tokenSet.CookieToken);
             }
 
             return Serialize(tokenSet);
         }
 
         /// <inheritdoc />
-        public AntiforgeryTokenSet GetTokens(HttpContext context)
+        public AntiforgeryTokenSet GetTokens(HttpContext httpContext)
         {
-            if (context == null)
+            if (httpContext == null)
             {
-                throw new ArgumentNullException(nameof(context));
+                throw new ArgumentNullException(nameof(httpContext));
             }
 
-            CheckSSLConfig(context);
+            CheckSSLConfig(httpContext);
 
-            var tokenSet = GetTokensInternal(context);
+            var tokenSet = GetTokensInternal(httpContext);
             return Serialize(tokenSet);
         }
 
         /// <inheritdoc />
-        public async Task ValidateRequestAsync(HttpContext context)
+        public async Task<bool> IsRequestValidAsync(HttpContext httpContext)
         {
-            if (context == null)
+            if (httpContext == null)
             {
-                throw new ArgumentNullException(nameof(context));
+                throw new ArgumentNullException(nameof(httpContext));
             }
 
-            CheckSSLConfig(context);
+            CheckSSLConfig(httpContext);
 
-            var tokens = await _tokenStore.GetRequestTokensAsync(context);
-            ValidateTokens(context, tokens);
+            var tokens = await _tokenStore.GetRequestTokensAsync(httpContext);
+
+            // Extract cookie & request tokens
+            var deserializedCookieToken = _tokenSerializer.Deserialize(tokens.CookieToken);
+            var deserializedRequestToken = _tokenSerializer.Deserialize(tokens.RequestToken);
+
+            // Validate
+            string message;
+            return _tokenGenerator.TryValidateTokenSet(
+                httpContext,
+                deserializedCookieToken,
+                deserializedRequestToken,
+                out message);
         }
 
         /// <inheritdoc />
-        public void ValidateTokens(HttpContext context, AntiforgeryTokenSet antiforgeryTokenSet)
+        public async Task ValidateRequestAsync(HttpContext httpContext)
         {
-            if (context == null)
+            if (httpContext == null)
             {
-                throw new ArgumentNullException(nameof(context));
+                throw new ArgumentNullException(nameof(httpContext));
             }
 
-            CheckSSLConfig(context);
+            CheckSSLConfig(httpContext);
+
+            var tokens = await _tokenStore.GetRequestTokensAsync(httpContext);
+            ValidateTokens(httpContext, tokens);
+        }
+
+        /// <inheritdoc />
+        public void ValidateTokens(HttpContext httpContext, AntiforgeryTokenSet antiforgeryTokenSet)
+        {
+            if (httpContext == null)
+            {
+                throw new ArgumentNullException(nameof(httpContext));
+            }
+
+            CheckSSLConfig(httpContext);
 
             if (string.IsNullOrEmpty(antiforgeryTokenSet.CookieToken))
             {
@@ -125,35 +150,40 @@ namespace Microsoft.AspNetCore.Antiforgery
             var deserializedRequestToken = _tokenSerializer.Deserialize(antiforgeryTokenSet.RequestToken);
 
             // Validate
-            _tokenGenerator.ValidateTokens(
-                context,
+            string message;
+            if (!_tokenGenerator.TryValidateTokenSet(
+                httpContext,
                 deserializedCookieToken,
-                deserializedRequestToken);
+                deserializedRequestToken,
+                out message))
+            {
+                throw new AntiforgeryValidationException(message);
+            }
         }
 
         /// <inheritdoc />
-        public void SetCookieTokenAndHeader(HttpContext context)
+        public void SetCookieTokenAndHeader(HttpContext httpContext)
         {
-            if (context == null)
+            if (httpContext == null)
             {
-                throw new ArgumentNullException(nameof(context));
+                throw new ArgumentNullException(nameof(httpContext));
             }
 
-            CheckSSLConfig(context);
+            CheckSSLConfig(httpContext);
 
-            var cookieToken = GetCookieTokenDoesNotThrow(context);
-            cookieToken = ValidateAndGenerateNewCookieToken(cookieToken);
-            SaveCookieTokenAndHeader(context, cookieToken);
+            var cookieToken = GetCookieTokenDoesNotThrow(httpContext);
+            cookieToken = ValidateAndGenerateNewCookieToken(httpContext, cookieToken);
+            SaveCookieTokenAndHeader(httpContext, cookieToken);
         }
 
         // This method returns null if oldCookieToken is valid.
-        private AntiforgeryToken ValidateAndGenerateNewCookieToken(AntiforgeryToken cookieToken)
+        private AntiforgeryToken ValidateAndGenerateNewCookieToken(HttpContext httpContext, AntiforgeryToken cookieToken)
         {
-            if (!_tokenGenerator.IsCookieTokenValid(cookieToken))
+            if (!_tokenGenerator.IsCookieTokenValid(httpContext, cookieToken))
             {
                 // Need to make sure we're always operating with a good cookie token.
-                var newCookieToken = _tokenGenerator.GenerateCookieToken();
-                Debug.Assert(_tokenGenerator.IsCookieTokenValid(newCookieToken));
+                var newCookieToken = _tokenGenerator.GenerateCookieToken(httpContext);
+                Debug.Assert(_tokenGenerator.IsCookieTokenValid(httpContext, newCookieToken));
                 return newCookieToken;
             }
 
@@ -208,16 +238,16 @@ namespace Microsoft.AspNetCore.Antiforgery
             }
         }
 
-        private AntiforgeryTokenSetInternal GetTokensInternal(HttpContext context)
+        private AntiforgeryTokenSetInternal GetTokensInternal(HttpContext httpContext)
         {
-            var cookieToken = GetCookieTokenDoesNotThrow(context);
-            var newCookieToken = ValidateAndGenerateNewCookieToken(cookieToken);
+            var cookieToken = GetCookieTokenDoesNotThrow(httpContext);
+            var newCookieToken = ValidateAndGenerateNewCookieToken(httpContext, cookieToken);
             if (newCookieToken != null)
             {
                 cookieToken = newCookieToken;
             }
             var requestToken = _tokenGenerator.GenerateRequestToken(
-                context,
+                httpContext,
                 cookieToken);
 
             return new AntiforgeryTokenSetInternal()

--- a/src/Microsoft.AspNetCore.Antiforgery/DefaultAntiforgery.cs
+++ b/src/Microsoft.AspNetCore.Antiforgery/DefaultAntiforgery.cs
@@ -172,18 +172,18 @@ namespace Microsoft.AspNetCore.Antiforgery
             CheckSSLConfig(httpContext);
 
             var cookieToken = GetCookieTokenDoesNotThrow(httpContext);
-            cookieToken = ValidateAndGenerateNewCookieToken(httpContext, cookieToken);
+            cookieToken = ValidateAndGenerateNewCookieToken(cookieToken);
             SaveCookieTokenAndHeader(httpContext, cookieToken);
         }
 
         // This method returns null if oldCookieToken is valid.
-        private AntiforgeryToken ValidateAndGenerateNewCookieToken(HttpContext httpContext, AntiforgeryToken cookieToken)
+        private AntiforgeryToken ValidateAndGenerateNewCookieToken(AntiforgeryToken cookieToken)
         {
-            if (!_tokenGenerator.IsCookieTokenValid(httpContext, cookieToken))
+            if (!_tokenGenerator.IsCookieTokenValid(cookieToken))
             {
                 // Need to make sure we're always operating with a good cookie token.
-                var newCookieToken = _tokenGenerator.GenerateCookieToken(httpContext);
-                Debug.Assert(_tokenGenerator.IsCookieTokenValid(httpContext, newCookieToken));
+                var newCookieToken = _tokenGenerator.GenerateCookieToken();
+                Debug.Assert(_tokenGenerator.IsCookieTokenValid(newCookieToken));
                 return newCookieToken;
             }
 
@@ -241,7 +241,7 @@ namespace Microsoft.AspNetCore.Antiforgery
         private AntiforgeryTokenSetInternal GetTokensInternal(HttpContext httpContext)
         {
             var cookieToken = GetCookieTokenDoesNotThrow(httpContext);
-            var newCookieToken = ValidateAndGenerateNewCookieToken(httpContext, cookieToken);
+            var newCookieToken = ValidateAndGenerateNewCookieToken(cookieToken);
             if (newCookieToken != null)
             {
                 cookieToken = newCookieToken;

--- a/src/Microsoft.AspNetCore.Antiforgery/DefaultAntiforgeryTokenGenerator.cs
+++ b/src/Microsoft.AspNetCore.Antiforgery/DefaultAntiforgeryTokenGenerator.cs
@@ -22,7 +22,7 @@ namespace Microsoft.AspNetCore.Antiforgery
         }
 
         /// <inheritdoc />
-        public AntiforgeryToken GenerateCookieToken(HttpContext httpContext)
+        public AntiforgeryToken GenerateCookieToken()
         {
             return new AntiforgeryToken()
             {
@@ -46,10 +46,10 @@ namespace Microsoft.AspNetCore.Antiforgery
                 throw new ArgumentNullException(nameof(cookieToken));
             }
 
-            if (!IsCookieTokenValid(httpContext, cookieToken))
+            if (!IsCookieTokenValid(cookieToken))
             {
                 throw new ArgumentException(
-                    Resources.Antiforgery_CookieToken_MustBeProvided_Generic,
+                    Resources.Antiforgery_CookieToken_IsInvalid,
                     nameof(cookieToken));
             }
 
@@ -99,7 +99,7 @@ namespace Microsoft.AspNetCore.Antiforgery
         }
 
         /// <inheritdoc />
-        public bool IsCookieTokenValid(HttpContext httpContext, AntiforgeryToken cookieToken)
+        public bool IsCookieTokenValid(AntiforgeryToken cookieToken)
         {
             return cookieToken != null && cookieToken.IsCookieToken;
         }

--- a/src/Microsoft.AspNetCore.Antiforgery/DefaultAntiforgeryTokenGenerator.cs
+++ b/src/Microsoft.AspNetCore.Antiforgery/DefaultAntiforgeryTokenGenerator.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Diagnostics;
 using System.Security.Claims;
 using System.Security.Principal;
 using Microsoft.AspNetCore.Http;
@@ -22,7 +21,8 @@ namespace Microsoft.AspNetCore.Antiforgery
             _additionalDataProvider = additionalDataProvider;
         }
 
-        public AntiforgeryToken GenerateCookieToken()
+        /// <inheritdoc />
+        public AntiforgeryToken GenerateCookieToken(HttpContext httpContext)
         {
             return new AntiforgeryToken()
             {
@@ -31,6 +31,7 @@ namespace Microsoft.AspNetCore.Antiforgery
             };
         }
 
+        /// <inheritdoc />
         public AntiforgeryToken GenerateRequestToken(
             HttpContext httpContext,
             AntiforgeryToken cookieToken)
@@ -40,7 +41,17 @@ namespace Microsoft.AspNetCore.Antiforgery
                 throw new ArgumentNullException(nameof(httpContext));
             }
 
-            Debug.Assert(IsCookieTokenValid(cookieToken));
+            if (cookieToken == null)
+            {
+                throw new ArgumentNullException(nameof(cookieToken));
+            }
+
+            if (!IsCookieTokenValid(httpContext, cookieToken))
+            {
+                throw new ArgumentException(
+                    Resources.Antiforgery_CookieToken_MustBeProvided_Generic,
+                    nameof(cookieToken));
+            }
 
             var requestToken = new AntiforgeryToken()
             {
@@ -87,15 +98,18 @@ namespace Microsoft.AspNetCore.Antiforgery
             return requestToken;
         }
 
-        public bool IsCookieTokenValid(AntiforgeryToken cookieToken)
+        /// <inheritdoc />
+        public bool IsCookieTokenValid(HttpContext httpContext, AntiforgeryToken cookieToken)
         {
-            return (cookieToken != null && cookieToken.IsCookieToken);
+            return cookieToken != null && cookieToken.IsCookieToken;
         }
 
-        public void ValidateTokens(
+        /// <inheritdoc />
+        public bool TryValidateTokenSet(
             HttpContext httpContext,
             AntiforgeryToken cookieToken,
-            AntiforgeryToken requestToken)
+            AntiforgeryToken requestToken,
+            out string message)
         {
             if (httpContext == null)
             {
@@ -119,13 +133,15 @@ namespace Microsoft.AspNetCore.Antiforgery
             // Do the tokens have the correct format?
             if (!cookieToken.IsCookieToken || requestToken.IsCookieToken)
             {
-                throw new AntiforgeryValidationException(Resources.AntiforgeryToken_TokensSwapped);
+                message = Resources.AntiforgeryToken_TokensSwapped;
+                return false;
             }
 
             // Are the security tokens embedded in each incoming token identical?
             if (!object.Equals(cookieToken.SecurityToken, requestToken.SecurityToken))
             {
-                throw new AntiforgeryValidationException(Resources.AntiforgeryToken_SecurityTokenMismatch);
+                message = Resources.AntiforgeryToken_SecurityTokenMismatch;
+                return false;
             }
 
             // Is the incoming token meant for the current user?
@@ -153,21 +169,26 @@ namespace Microsoft.AspNetCore.Antiforgery
 
             if (!comparer.Equals(requestToken.Username, currentUsername))
             {
-                throw new AntiforgeryValidationException(
-                    Resources.FormatAntiforgeryToken_UsernameMismatch(requestToken.Username, currentUsername));
+                message = Resources.FormatAntiforgeryToken_UsernameMismatch(requestToken.Username, currentUsername);
+                return false;
             }
 
             if (!object.Equals(requestToken.ClaimUid, currentClaimUid))
             {
-                throw new AntiforgeryValidationException(Resources.AntiforgeryToken_ClaimUidMismatch);
+                message = Resources.AntiforgeryToken_ClaimUidMismatch;
+                return false;
             }
 
             // Is the AdditionalData valid?
             if (_additionalDataProvider != null &&
                 !_additionalDataProvider.ValidateAdditionalData(httpContext, requestToken.AdditionalData))
             {
-                throw new AntiforgeryValidationException(Resources.AntiforgeryToken_AdditionalDataCheckFailed);
+                message = Resources.AntiforgeryToken_AdditionalDataCheckFailed;
+                return false;
             }
+
+            message = null;
+            return true;
         }
 
         private static BinaryBlob GetClaimUidBlob(string base64ClaimUid)

--- a/src/Microsoft.AspNetCore.Antiforgery/IAntiforgery.cs
+++ b/src/Microsoft.AspNetCore.Antiforgery/IAntiforgery.cs
@@ -16,7 +16,7 @@ namespace Microsoft.AspNetCore.Antiforgery
         /// <summary>
         /// Generates an &lt;input type="hidden"&gt; element for an antiforgery token.
         /// </summary>
-        /// <param name="context">The <see cref="HttpContext"/> associated with the current request.</param>
+        /// <param name="httpContext">The <see cref="HttpContext"/> associated with the current request.</param>
         /// <returns>
         /// A <see cref="IHtmlContent"/> containing an &lt;input type="hidden"&gt; element. This element should be put
         /// inside a &lt;form&gt;.
@@ -25,50 +25,63 @@ namespace Microsoft.AspNetCore.Antiforgery
         /// This method has a side effect:
         /// A response cookie is set if there is no valid cookie associated with the request.
         /// </remarks>
-        IHtmlContent GetHtml(HttpContext context);
+        IHtmlContent GetHtml(HttpContext httpContext);
 
         /// <summary>
         /// Generates an <see cref="AntiforgeryTokenSet"/> for this request and stores the cookie token
         /// in the response.
         /// </summary>
-        /// <param name="context">The <see cref="HttpContext"/> associated with the current request.</param>
+        /// <param name="httpContext">The <see cref="HttpContext"/> associated with the current request.</param>
         /// <returns>An <see cref="AntiforgeryTokenSet" /> with tokens for the response.</returns>
         /// <remarks>
         /// This method has a side effect:
         /// A response cookie is set if there is no valid cookie associated with the request.
         /// </remarks>
-        AntiforgeryTokenSet GetAndStoreTokens(HttpContext context);
+        AntiforgeryTokenSet GetAndStoreTokens(HttpContext httpContext);
 
         /// <summary>
         /// Generates an <see cref="AntiforgeryTokenSet"/> for this request.
         /// </summary>
-        /// <param name="context">The <see cref="HttpContext"/> associated with the current request.</param>
+        /// <param name="httpContext">The <see cref="HttpContext"/> associated with the current request.</param>
         /// <remarks>
         /// Unlike <see cref="GetAndStoreTokens(HttpContext)"/>, this method has no side effect. The caller
         /// is responsible for setting the response cookie and injecting the returned
         /// form token as appropriate.
         /// </remarks>
-        AntiforgeryTokenSet GetTokens(HttpContext context);
+        AntiforgeryTokenSet GetTokens(HttpContext httpContext);
+
+        /// <summary>
+        /// Asynchronously returns a value indicating whether the request contains a valid antiforgery token.
+        /// </summary>
+        /// <param name="httpContext">The <see cref="HttpContext"/> associated with the current request.</param>
+        /// <returns>
+        /// A <see cref="Task{bool}"/> that, when completed, returns <c>true</c> if the request contains a
+        /// valid antiforgery token, otherwise returns <c>false</c>.
+        /// </returns>
+        Task<bool> IsRequestValidAsync(HttpContext httpContext);
 
         /// <summary>
         /// Validates an antiforgery token that was supplied as part of the request.
         /// </summary>
-        /// <param name="context">The <see cref="HttpContext"/> associated with the current request.</param>
-        Task ValidateRequestAsync(HttpContext context);
+        /// <param name="httpContext">The <see cref="HttpContext"/> associated with the current request.</param>
+        /// <exception cref="AntiforgeryValidationException">
+        /// Thrown when the request does not include a valid antiforgery token.
+        /// </exception>
+        Task ValidateRequestAsync(HttpContext httpContext);
 
         /// <summary>
         /// Validates an <see cref="AntiforgeryTokenSet"/> for the current request.
         /// </summary>
-        /// <param name="context">The <see cref="HttpContext"/> associated with the current request.</param>
+        /// <param name="httpContext">The <see cref="HttpContext"/> associated with the current request.</param>
         /// <param name="antiforgeryTokenSet">
         /// The <see cref="AntiforgeryTokenSet"/> (cookie and request token) for this request.
         /// </param>
-        void ValidateTokens(HttpContext context, AntiforgeryTokenSet antiforgeryTokenSet);
+        void ValidateTokens(HttpContext httpContext, AntiforgeryTokenSet antiforgeryTokenSet);
 
         /// <summary>
         /// Generates and stores an antiforgery cookie token if one is not available or not valid.
         /// </summary>
-        /// <param name="context">The <see cref="HttpContext"/> associated with the current request.</param>
-        void SetCookieTokenAndHeader(HttpContext context);
+        /// <param name="httpContext">The <see cref="HttpContext"/> associated with the current request.</param>
+        void SetCookieTokenAndHeader(HttpContext httpContext);
     }
 }

--- a/src/Microsoft.AspNetCore.Antiforgery/IAntiforgeryTokenGenerator.cs
+++ b/src/Microsoft.AspNetCore.Antiforgery/IAntiforgeryTokenGenerator.cs
@@ -13,9 +13,8 @@ namespace Microsoft.AspNetCore.Antiforgery
         /// <summary>
         /// Generates a new random cookie token.
         /// </summary>
-        /// <param name="httpContext">The <see cref="HttpContext"/> associated with the current request.</param>
         /// <returns>An <see cref="AntiforgeryToken"/>.</returns>
-        AntiforgeryToken GenerateCookieToken(HttpContext httpContext);
+        AntiforgeryToken GenerateCookieToken();
 
         // Given a cookie token, generates a corresponding request token.
         // The incoming cookie token must be valid.
@@ -29,12 +28,11 @@ namespace Microsoft.AspNetCore.Antiforgery
         AntiforgeryToken GenerateRequestToken(HttpContext httpContext, AntiforgeryToken cookieToken);
 
         /// <summary>
-        /// Attempts to validate a cookie token for the given <paramref name="httpContext"/>/
+        /// Attempts to validate a cookie token.
         /// </summary>
-        /// <param name="httpContext">The <see cref="HttpContext"/> associated with the current request.</param>
         /// <param name="cookieToken">A valid cookie token.</param>
         /// <returns><c>true</c> if the cookie token is valid, otherwise <c>false</c>.</returns>
-        bool IsCookieTokenValid(HttpContext httpContext, AntiforgeryToken cookieToken);
+        bool IsCookieTokenValid(AntiforgeryToken cookieToken);
 
         /// <summary>
         /// Attempts to validate a cookie and request token set for the given <paramref name="httpContext"/>.

--- a/src/Microsoft.AspNetCore.Antiforgery/IAntiforgeryTokenGenerator.cs
+++ b/src/Microsoft.AspNetCore.Antiforgery/IAntiforgeryTokenGenerator.cs
@@ -10,23 +10,46 @@ namespace Microsoft.AspNetCore.Antiforgery
     /// </summary>
     public interface IAntiforgeryTokenGenerator
     {
-        // Generates a new random cookie token.
-        AntiforgeryToken GenerateCookieToken();
+        /// <summary>
+        /// Generates a new random cookie token.
+        /// </summary>
+        /// <param name="httpContext">The <see cref="HttpContext"/> associated with the current request.</param>
+        /// <returns>An <see cref="AntiforgeryToken"/>.</returns>
+        AntiforgeryToken GenerateCookieToken(HttpContext httpContext);
 
         // Given a cookie token, generates a corresponding request token.
         // The incoming cookie token must be valid.
-        AntiforgeryToken GenerateRequestToken(
-            HttpContext httpContext,
-            AntiforgeryToken cookieToken);
 
-        // Determines whether an existing cookie token is valid (well-formed).
-        // If it is not, the caller must call GenerateCookieToken() before calling GenerateFormToken().
-        bool IsCookieTokenValid(AntiforgeryToken cookieToken);
+        /// <summary>
+        /// Generates a request token corresponding to <paramref name="cookieToken"/>.
+        /// </summary>
+        /// <param name="httpContext">The <see cref="HttpContext"/> associated with the current request.</param>
+        /// <param name="cookieToken">A valid cookie token.</param>
+        /// <returns>An <see cref="AntiforgeryToken"/>.</returns>
+        AntiforgeryToken GenerateRequestToken(HttpContext httpContext, AntiforgeryToken cookieToken);
 
-        // Validates a (cookie, request) token pair.
-        void ValidateTokens(
+        /// <summary>
+        /// Attempts to validate a cookie token for the given <paramref name="httpContext"/>/
+        /// </summary>
+        /// <param name="httpContext">The <see cref="HttpContext"/> associated with the current request.</param>
+        /// <param name="cookieToken">A valid cookie token.</param>
+        /// <returns><c>true</c> if the cookie token is valid, otherwise <c>false</c>.</returns>
+        bool IsCookieTokenValid(HttpContext httpContext, AntiforgeryToken cookieToken);
+
+        /// <summary>
+        /// Attempts to validate a cookie and request token set for the given <paramref name="httpContext"/>.
+        /// </summary>
+        /// <param name="httpContext">The <see cref="HttpContext"/> associated with the current request.</param>
+        /// <param name="cookieToken">A cookie token.</param>
+        /// <param name="requestToken">A request token.</param>
+        /// <param name="message">
+        /// Will be set to the validation message if the tokens are invalid, otherwise <c>null</c>.
+        /// </param>
+        /// <returns><c>true</c> if the tokens are valid, otherwise <c>false</c>.</returns>
+        bool TryValidateTokenSet(
             HttpContext httpContext,
             AntiforgeryToken cookieToken,
-            AntiforgeryToken requestToken);
+            AntiforgeryToken requestToken,
+            out string message);
     }
 }

--- a/src/Microsoft.AspNetCore.Antiforgery/Properties/Resources.Designer.cs
+++ b/src/Microsoft.AspNetCore.Antiforgery/Properties/Resources.Designer.cs
@@ -141,6 +141,14 @@ namespace Microsoft.AspNetCore.Antiforgery
         /// <summary>
         /// The required antiforgery cookie "{0}" is not present.
         /// </summary>
+        internal static string Antiforgery_CookieToken_IsInvalid
+        {
+            get { return GetString("Antiforgery_CookieToken_IsInvalid"); }
+        }
+
+        /// <summary>
+        /// The required antiforgery cookie "{0}" is not present.
+        /// </summary>
         internal static string Antiforgery_CookieToken_MustBeProvided
         {
             get { return GetString("Antiforgery_CookieToken_MustBeProvided"); }

--- a/src/Microsoft.AspNetCore.Antiforgery/Resources.resx
+++ b/src/Microsoft.AspNetCore.Antiforgery/Resources.resx
@@ -143,6 +143,9 @@
     <value>The antiforgery system has the configuration value {0}.{1} = {2}, but the current request is not an SSL request.</value>
     <comment>0 = nameof(AntiforgeryOptions), 1 = nameof(RequireSsl), 2 = bool.TrueString</comment>
   </data>
+  <data name="Antiforgery_CookieToken_IsInvalid" xml:space="preserve">
+    <value>The antiforgery cookie token is invalid.</value>
+  </data>
   <data name="Antiforgery_CookieToken_MustBeProvided" xml:space="preserve">
     <value>The required antiforgery cookie "{0}" is not present.</value>
   </data>

--- a/test/Microsoft.AspNetCore.Antiforgery.Test/project.json
+++ b/test/Microsoft.AspNetCore.Antiforgery.Test/project.json
@@ -6,6 +6,7 @@
   "dependencies": {
     "Microsoft.AspNetCore.Antiforgery": "1.0.0-*",
     "Microsoft.AspNetCore.Http": "1.0.0-*",
+    "Microsoft.AspNetCore.Testing": "1.0.0-*",
     "Microsoft.Extensions.DependencyInjection": "1.0.0-*",
     "Microsoft.Extensions.WebEncoders": "1.0.0-*",
     "Microsoft.NETCore.Platforms": "1.0.1-*",


### PR DESCRIPTION
We want a non-throwing way to validate for use in auth.

Some other misc cleanup
- docs for IAntiforgeryTokenGenerator
~~- Add HttpContext parameter where to all IAntiforgeryGenerator methods~~
- rename parameters on DefaultAntiforgery