### PR TITLE
Remove `ValidateTokens()` from `IAntiforgery`

### DIFF
--- a/src/Microsoft.AspNetCore.Antiforgery/IAntiforgery.cs
+++ b/src/Microsoft.AspNetCore.Antiforgery/IAntiforgery.cs
@@ -55,15 +55,6 @@ namespace Microsoft.AspNetCore.Antiforgery
         Task ValidateRequestAsync(HttpContext httpContext);
 
         /// <summary>
-        /// Validates an <see cref="AntiforgeryTokenSet"/> for the current request.
-        /// </summary>
-        /// <param name="httpContext">The <see cref="HttpContext"/> associated with the current request.</param>
-        /// <param name="antiforgeryTokenSet">
-        /// The <see cref="AntiforgeryTokenSet"/> (cookie and request token) for this request.
-        /// </param>
-        void ValidateTokens(HttpContext httpContext, AntiforgeryTokenSet antiforgeryTokenSet);
-
-        /// <summary>
         /// Generates and stores an antiforgery cookie token if one is not available or not valid.
         /// </summary>
         /// <param name="httpContext">The <see cref="HttpContext"/> associated with the current request.</param>

--- a/src/Microsoft.AspNetCore.Antiforgery/Internal/DefaultAntiforgery.cs
+++ b/src/Microsoft.AspNetCore.Antiforgery/Internal/DefaultAntiforgery.cs
@@ -136,7 +136,7 @@ namespace Microsoft.AspNetCore.Antiforgery.Internal
         }
 
         // Internal for testing
-        internal void ValidateTokens(HttpContext httpContext, AntiforgeryTokenSet antiforgeryTokenSet)
+        private void ValidateTokens(HttpContext httpContext, AntiforgeryTokenSet antiforgeryTokenSet)
         {
             if (httpContext == null)
             {

--- a/src/Microsoft.AspNetCore.Antiforgery/Internal/DefaultAntiforgery.cs
+++ b/src/Microsoft.AspNetCore.Antiforgery/Internal/DefaultAntiforgery.cs
@@ -135,8 +135,8 @@ namespace Microsoft.AspNetCore.Antiforgery.Internal
             ValidateTokens(httpContext, tokens);
         }
 
-        /// <inheritdoc />
-        public void ValidateTokens(HttpContext httpContext, AntiforgeryTokenSet antiforgeryTokenSet)
+        // Internal for testing
+        internal void ValidateTokens(HttpContext httpContext, AntiforgeryTokenSet antiforgeryTokenSet)
         {
             if (httpContext == null)
             {


### PR DESCRIPTION
- `IAntiforgery` does not expose a way to get an invalid `AntiforgeryTokenSet`