### PR TITLE
Serialize cookie token at most once

### DIFF
--- a/src/Microsoft.AspNetCore.Antiforgery/Internal/AntiforgeryContext.cs
+++ b/src/Microsoft.AspNetCore.Antiforgery/Internal/AntiforgeryContext.cs
@@ -4,10 +4,31 @@
 namespace Microsoft.AspNetCore.Antiforgery.Internal
 {
     /// <summary>
-    /// Used as a per request state.
+    /// Used to hold per-request state.
     /// </summary>
     public class AntiforgeryContext
     {
+        public bool HaveDeserializedCookieToken { get; set; }
+
         public AntiforgeryToken CookieToken { get; set; }
+
+        public bool HaveDeserializedRequestToken { get; set; }
+
+        public AntiforgeryToken RequestToken { get; set; }
+
+        public bool HaveGeneratedNewCookieToken { get; set; }
+
+        // After HaveGeneratedNewCookieToken is true, remains null if CookieToken is valid.
+        public AntiforgeryToken NewCookieToken { get; set; }
+
+        // After HaveGeneratedNewCookieToken is true, remains null if CookieToken is valid.
+        public string NewCookieTokenString { get; set; }
+
+        public AntiforgeryToken NewRequestToken { get; set; }
+
+        public string NewRequestTokenString { get; set; }
+
+        // Always false if NewCookieToken is null. Never store null cookie token or re-store cookie token from request.
+        public bool HaveStoredNewCookieToken { get; set; }
     }
 }

--- a/src/Microsoft.AspNetCore.Antiforgery/Internal/DefaultAntiforgery.cs
+++ b/src/Microsoft.AspNetCore.Antiforgery/Internal/DefaultAntiforgery.cs
@@ -140,26 +140,8 @@ namespace Microsoft.AspNetCore.Antiforgery.Internal
 
         private void ValidateTokens(HttpContext httpContext, AntiforgeryTokenSet antiforgeryTokenSet)
         {
-            if (httpContext == null)
-            {
-                throw new ArgumentNullException(nameof(httpContext));
-            }
-
-            CheckSSLConfig(httpContext);
-
-            if (string.IsNullOrEmpty(antiforgeryTokenSet.CookieToken))
-            {
-                throw new ArgumentException(
-                    Resources.Antiforgery_CookieToken_MustBeProvided_Generic,
-                    nameof(antiforgeryTokenSet));
-            }
-
-            if (string.IsNullOrEmpty(antiforgeryTokenSet.RequestToken))
-            {
-                throw new ArgumentException(
-                    Resources.Antiforgery_RequestToken_MustBeProvided_Generic,
-                    nameof(antiforgeryTokenSet));
-            }
+            Debug.Assert(!string.IsNullOrEmpty(antiforgeryTokenSet.CookieToken));
+            Debug.Assert(!string.IsNullOrEmpty(antiforgeryTokenSet.RequestToken));
 
             // Extract cookie & request tokens
             AntiforgeryToken deserializedCookieToken;
@@ -233,26 +215,22 @@ namespace Microsoft.AspNetCore.Antiforgery.Internal
 
             CheckSSLConfig(httpContext);
 
-            var contextAccessor = GetCookieTokens(httpContext);
-            if (!contextAccessor.HaveStoredNewCookieToken && contextAccessor.NewCookieToken != null)
+            var antiforgeryContext = GetCookieTokens(httpContext);
+            if (!antiforgeryContext.HaveStoredNewCookieToken && antiforgeryContext.NewCookieToken != null)
             {
-                if (contextAccessor.NewCookieTokenString == null)
+                if (antiforgeryContext.NewCookieTokenString == null)
                 {
-                    contextAccessor.NewCookieTokenString = _tokenSerializer.Serialize(contextAccessor.NewCookieToken);
+                    antiforgeryContext.NewCookieTokenString =
+                        _tokenSerializer.Serialize(antiforgeryContext.NewCookieToken);
                 }
 
-                SaveCookieTokenAndHeader(httpContext, contextAccessor.NewCookieTokenString);
-                contextAccessor.HaveStoredNewCookieToken = true;
+                SaveCookieTokenAndHeader(httpContext, antiforgeryContext.NewCookieTokenString);
+                antiforgeryContext.HaveStoredNewCookieToken = true;
             }
         }
 
         private void SaveCookieTokenAndHeader(HttpContext httpContext, string cookieToken)
         {
-            if (httpContext == null)
-            {
-                throw new ArgumentNullException(nameof(httpContext));
-            }
-
             if (cookieToken != null)
             {
                 // Persist the new cookie if it is not null.

--- a/src/Microsoft.AspNetCore.Antiforgery/Internal/DefaultAntiforgeryTokenStore.cs
+++ b/src/Microsoft.AspNetCore.Antiforgery/Internal/DefaultAntiforgeryTokenStore.cs
@@ -2,10 +2,8 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Diagnostics;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
-using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using Microsoft.Extensions.Primitives;
 
@@ -14,38 +12,22 @@ namespace Microsoft.AspNetCore.Antiforgery.Internal
     public class DefaultAntiforgeryTokenStore : IAntiforgeryTokenStore
     {
         private readonly AntiforgeryOptions _options;
-        private readonly IAntiforgeryTokenSerializer _tokenSerializer;
 
-        public DefaultAntiforgeryTokenStore(
-            IOptions<AntiforgeryOptions> optionsAccessor,
-            IAntiforgeryTokenSerializer tokenSerializer)
+        public DefaultAntiforgeryTokenStore(IOptions<AntiforgeryOptions> optionsAccessor)
         {
             if (optionsAccessor == null)
             {
                 throw new ArgumentNullException(nameof(optionsAccessor));
             }
 
-            if (tokenSerializer == null)
-            {
-                throw new ArgumentNullException(nameof(tokenSerializer));
-            }
-
             _options = optionsAccessor.Value;
-            _tokenSerializer = tokenSerializer;
         }
 
-        public AntiforgeryToken GetCookieToken(HttpContext httpContext)
+        public string GetCookieToken(HttpContext httpContext)
         {
             if (httpContext == null)
             {
                 throw new ArgumentNullException(nameof(httpContext));
-            }
-
-            var services = httpContext.RequestServices;
-            var contextAccessor = services.GetRequiredService<IAntiforgeryContextAccessor>();
-            if (contextAccessor.Value != null)
-            {
-                return contextAccessor.Value.CookieToken;
             }
 
             var requestCookie = httpContext.Request.Cookies[_options.CookieName];
@@ -55,7 +37,7 @@ namespace Microsoft.AspNetCore.Antiforgery.Internal
                 return null;
             }
 
-            return _tokenSerializer.Deserialize(requestCookie);
+            return requestCookie;
         }
 
         public async Task<AntiforgeryTokenSet> GetRequestTokensAsync(HttpContext httpContext)
@@ -85,7 +67,7 @@ namespace Microsoft.AspNetCore.Antiforgery.Internal
             return new AntiforgeryTokenSet(requestToken, cookieToken, _options.FormFieldName, _options.HeaderName);
         }
 
-        public void SaveCookieToken(HttpContext httpContext, AntiforgeryToken token)
+        public void SaveCookieToken(HttpContext httpContext, string token)
         {
             if (httpContext == null)
             {
@@ -97,15 +79,6 @@ namespace Microsoft.AspNetCore.Antiforgery.Internal
                 throw new ArgumentNullException(nameof(token));
             }
 
-            // Add the cookie to the request based context.
-            // This is useful if the cookie needs to be reloaded in the context of the same request.
-
-            var services = httpContext.RequestServices;
-            var contextAccessor = services.GetRequiredService<IAntiforgeryContextAccessor>();
-            Debug.Assert(contextAccessor.Value == null, "AntiforgeryContext should be set only once per request.");
-            contextAccessor.Value = new AntiforgeryContext() { CookieToken = token };
-
-            var serializedToken = _tokenSerializer.Serialize(token);
             var options = new CookieOptions() { HttpOnly = true };
 
             // Note: don't use "newCookie.Secure = _options.RequireSSL;" since the default
@@ -115,7 +88,7 @@ namespace Microsoft.AspNetCore.Antiforgery.Internal
                 options.Secure = true;
             }
 
-            httpContext.Response.Cookies.Append(_options.CookieName, serializedToken, options);
+            httpContext.Response.Cookies.Append(_options.CookieName, token, options);
         }
     }
 }

--- a/src/Microsoft.AspNetCore.Antiforgery/Internal/DefaultAntiforgeryTokenStore.cs
+++ b/src/Microsoft.AspNetCore.Antiforgery/Internal/DefaultAntiforgeryTokenStore.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Diagnostics;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Options;
@@ -25,10 +26,7 @@ namespace Microsoft.AspNetCore.Antiforgery.Internal
 
         public string GetCookieToken(HttpContext httpContext)
         {
-            if (httpContext == null)
-            {
-                throw new ArgumentNullException(nameof(httpContext));
-            }
+            Debug.Assert(httpContext != null);
 
             var requestCookie = httpContext.Request.Cookies[_options.CookieName];
             if (string.IsNullOrEmpty(requestCookie))
@@ -42,10 +40,7 @@ namespace Microsoft.AspNetCore.Antiforgery.Internal
 
         public async Task<AntiforgeryTokenSet> GetRequestTokensAsync(HttpContext httpContext)
         {
-            if (httpContext == null)
-            {
-                throw new ArgumentNullException(nameof(httpContext));
-            }
+            Debug.Assert(httpContext != null);
 
             var cookieToken = httpContext.Request.Cookies[_options.CookieName];
 
@@ -69,15 +64,8 @@ namespace Microsoft.AspNetCore.Antiforgery.Internal
 
         public void SaveCookieToken(HttpContext httpContext, string token)
         {
-            if (httpContext == null)
-            {
-                throw new ArgumentNullException(nameof(httpContext));
-            }
-
-            if (token == null)
-            {
-                throw new ArgumentNullException(nameof(token));
-            }
+            Debug.Assert(httpContext != null);
+            Debug.Assert(token != null);
 
             var options = new CookieOptions() { HttpOnly = true };
 

--- a/src/Microsoft.AspNetCore.Antiforgery/Internal/IAntiforgeryTokenStore.cs
+++ b/src/Microsoft.AspNetCore.Antiforgery/Internal/IAntiforgeryTokenStore.cs
@@ -8,7 +8,7 @@ namespace Microsoft.AspNetCore.Antiforgery.Internal
 {
     public interface IAntiforgeryTokenStore
     {
-        AntiforgeryToken GetCookieToken(HttpContext httpContext);
+        string GetCookieToken(HttpContext httpContext);
 
         /// <summary>
         /// Gets the cookie and request tokens from the request.
@@ -17,6 +17,6 @@ namespace Microsoft.AspNetCore.Antiforgery.Internal
         /// <returns>The <see cref="AntiforgeryTokenSet"/>.</returns>
         Task<AntiforgeryTokenSet> GetRequestTokensAsync(HttpContext httpContext);
 
-        void SaveCookieToken(HttpContext httpContext, AntiforgeryToken token);
+        void SaveCookieToken(HttpContext httpContext, string token);
     }
 }

--- a/test/Microsoft.AspNetCore.Antiforgery.Test/Internal/DefaultAntiforgeryTest.cs
+++ b/test/Microsoft.AspNetCore.Antiforgery.Test/Internal/DefaultAntiforgeryTest.cs
@@ -149,11 +149,10 @@ namespace Microsoft.AspNetCore.Antiforgery.Internal
                 useOldCookie: false,
                 isOldCookieValid: false);
 
-            // This will cause the cookieToken to be null.
+            // Exception will cause the cookieToken to be null.
             context.TokenSerializer
                 .Setup(o => o.Deserialize("serialized-old-cookie-token"))
                 .Throws(new Exception("should be swallowed"));
-            // So...
             context.TokenGenerator
                 .Setup(o => o.IsCookieTokenValid(null))
                 .Returns(false);

--- a/test/Microsoft.AspNetCore.Antiforgery.Test/Internal/DefaultAntiforgeryTokenStoreTest.cs
+++ b/test/Microsoft.AspNetCore.Antiforgery.Test/Internal/DefaultAntiforgeryTokenStoreTest.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
-using Microsoft.AspNetCore.DataProtection;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Internal;
 using Microsoft.Extensions.DependencyInjection;
@@ -31,42 +30,13 @@ namespace Microsoft.AspNetCore.Antiforgery.Internal
                 CookieName = _cookieName
             };
 
-            var tokenStore = new DefaultAntiforgeryTokenStore(
-                optionsAccessor: new TestOptionsManager(options),
-                tokenSerializer: Mock.Of<IAntiforgeryTokenSerializer>());
+            var tokenStore = new DefaultAntiforgeryTokenStore(new TestOptionsManager(options));
 
             // Act
             var token = tokenStore.GetCookieToken(httpContext);
 
             // Assert
             Assert.Null(token);
-        }
-
-        [Fact]
-        public void GetCookieToken_CookieIsMissingInRequest_LooksUpCookieInAntiforgeryContext()
-        {
-            // Arrange
-            var contextAccessor = new DefaultAntiforgeryContextAccessor();
-            var httpContext = GetHttpContext(_cookieName, string.Empty, contextAccessor);
-
-            // add a cookie explicitly.
-            var cookie = new AntiforgeryToken();
-            contextAccessor.Value = new AntiforgeryContext() { CookieToken = cookie };
-
-            var options = new AntiforgeryOptions
-            {
-                CookieName = _cookieName
-            };
-
-            var tokenStore = new DefaultAntiforgeryTokenStore(
-                optionsAccessor: new TestOptionsManager(options),
-                tokenSerializer: Mock.Of<IAntiforgeryTokenSerializer>());
-
-            // Act
-            var token = tokenStore.GetCookieToken(httpContext);
-
-            // Assert
-            Assert.Equal(cookie, token);
         }
 
         [Fact]
@@ -79,9 +49,7 @@ namespace Microsoft.AspNetCore.Antiforgery.Internal
                 CookieName = _cookieName
             };
 
-            var tokenStore = new DefaultAntiforgeryTokenStore(
-                optionsAccessor: new TestOptionsManager(options),
-                tokenSerializer: Mock.Of<IAntiforgeryTokenSerializer>());
+            var tokenStore = new DefaultAntiforgeryTokenStore(new TestOptionsManager(options));
 
             // Act
             var token = tokenStore.GetCookieToken(httpContext);
@@ -91,57 +59,24 @@ namespace Microsoft.AspNetCore.Antiforgery.Internal
         }
 
         [Fact]
-        public void GetCookieToken_CookieIsInvalid_PropagatesException()
+        public void GetCookieToken_CookieIsNotEmpty_ReturnsToken()
         {
             // Arrange
-            var httpContext = GetHttpContext(_cookieName, "invalid-value");
-
-            var expectedException = new AntiforgeryValidationException("some exception");
-            var mockSerializer = new Mock<IAntiforgeryTokenSerializer>();
-            mockSerializer
-                .Setup(o => o.Deserialize("invalid-value"))
-                .Throws(expectedException);
+            var expectedToken = "valid-value";
+            var httpContext = GetHttpContext(_cookieName, expectedToken);
 
             var options = new AntiforgeryOptions()
             {
                 CookieName = _cookieName
             };
 
-            var tokenStore = new DefaultAntiforgeryTokenStore(
-                optionsAccessor: new TestOptionsManager(options),
-                tokenSerializer: mockSerializer.Object);
-
-            // Act & assert
-            var ex = Assert.Throws<AntiforgeryValidationException>(() => tokenStore.GetCookieToken(httpContext));
-            Assert.Same(expectedException, ex);
-        }
-
-        [Fact]
-        public void GetCookieToken_CookieIsValid_ReturnsToken()
-        {
-            // Arrange
-            var expectedToken = new AntiforgeryToken();
-            var httpContext = GetHttpContext(_cookieName, "valid-value");
-
-            var mockSerializer = new Mock<IAntiforgeryTokenSerializer>();
-            mockSerializer
-                .Setup(o => o.Deserialize("valid-value"))
-                .Returns(expectedToken);
-
-            var options = new AntiforgeryOptions()
-            {
-                CookieName = _cookieName
-            };
-
-            var tokenStore = new DefaultAntiforgeryTokenStore(
-                optionsAccessor: new TestOptionsManager(options),
-                tokenSerializer: mockSerializer.Object);
+            var tokenStore = new DefaultAntiforgeryTokenStore(new TestOptionsManager(options));
 
             // Act
             var token = tokenStore.GetCookieToken(httpContext);
 
             // Assert
-            Assert.Same(expectedToken, token);
+            Assert.Equal(expectedToken, token);
         }
 
         [Fact]
@@ -157,9 +92,7 @@ namespace Microsoft.AspNetCore.Antiforgery.Internal
                 FormFieldName = "form-field-name",
             };
 
-            var tokenStore = new DefaultAntiforgeryTokenStore(
-                optionsAccessor: new TestOptionsManager(options),
-                tokenSerializer: Mock.Of<IAntiforgeryTokenSerializer>());
+            var tokenStore = new DefaultAntiforgeryTokenStore(new TestOptionsManager(options));
 
             // Act
             var tokenSet = await tokenStore.GetRequestTokensAsync(httpContext);
@@ -186,9 +119,7 @@ namespace Microsoft.AspNetCore.Antiforgery.Internal
                 HeaderName = null,
             };
 
-            var tokenStore = new DefaultAntiforgeryTokenStore(
-                optionsAccessor: new TestOptionsManager(options),
-                tokenSerializer: new DefaultAntiforgeryTokenSerializer(new EphemeralDataProtectionProvider(), _pool));
+            var tokenStore = new DefaultAntiforgeryTokenStore(new TestOptionsManager(options));
 
             // Act
             var tokenSet = await tokenStore.GetRequestTokensAsync(httpContext);
@@ -214,9 +145,7 @@ namespace Microsoft.AspNetCore.Antiforgery.Internal
                 HeaderName = "header-name",
             };
 
-            var tokenStore = new DefaultAntiforgeryTokenStore(
-                optionsAccessor: new TestOptionsManager(options),
-                tokenSerializer: new DefaultAntiforgeryTokenSerializer(new EphemeralDataProtectionProvider(), _pool));
+            var tokenStore = new DefaultAntiforgeryTokenStore(new TestOptionsManager(options));
 
             // Act
             var tokens = await tokenStore.GetRequestTokensAsync(httpContext);
@@ -244,9 +173,7 @@ namespace Microsoft.AspNetCore.Antiforgery.Internal
                 HeaderName = "header-name",
             };
 
-            var tokenStore = new DefaultAntiforgeryTokenStore(
-                optionsAccessor: new TestOptionsManager(options),
-                tokenSerializer: new DefaultAntiforgeryTokenSerializer(new EphemeralDataProtectionProvider(), _pool));
+            var tokenStore = new DefaultAntiforgeryTokenStore(new TestOptionsManager(options));
 
             // Act
             var tokens = await tokenStore.GetRequestTokensAsync(httpContext);
@@ -273,9 +200,7 @@ namespace Microsoft.AspNetCore.Antiforgery.Internal
                 HeaderName = "header-name",
             };
 
-            var tokenStore = new DefaultAntiforgeryTokenStore(
-                optionsAccessor: new TestOptionsManager(options),
-                tokenSerializer: new DefaultAntiforgeryTokenSerializer(new EphemeralDataProtectionProvider(), _pool));
+            var tokenStore = new DefaultAntiforgeryTokenStore(new TestOptionsManager(options));
 
             // Act
             var tokenSet = await tokenStore.GetRequestTokensAsync(httpContext);
@@ -300,9 +225,7 @@ namespace Microsoft.AspNetCore.Antiforgery.Internal
                 HeaderName = "header-name",
             };
 
-            var tokenStore = new DefaultAntiforgeryTokenStore(
-                optionsAccessor: new TestOptionsManager(options),
-                tokenSerializer: Mock.Of<IAntiforgeryTokenSerializer>());
+            var tokenStore = new DefaultAntiforgeryTokenStore(new TestOptionsManager(options));
 
             // Act
             var tokenSet = await tokenStore.GetRequestTokensAsync(httpContext);
@@ -331,9 +254,7 @@ namespace Microsoft.AspNetCore.Antiforgery.Internal
                 HeaderName = "header-name",
             };
 
-            var tokenStore = new DefaultAntiforgeryTokenStore(
-                optionsAccessor: new TestOptionsManager(options),
-                tokenSerializer: Mock.Of<IAntiforgeryTokenSerializer>());
+            var tokenStore = new DefaultAntiforgeryTokenStore(new TestOptionsManager(options));
 
             // Act
             var tokens = await tokenStore.GetRequestTokensAsync(httpContext);
@@ -349,7 +270,7 @@ namespace Microsoft.AspNetCore.Antiforgery.Internal
         public void SaveCookieToken(bool requireSsl, bool? expectedCookieSecureFlag)
         {
             // Arrange
-            var token = new AntiforgeryToken();
+            var token = "serialized-value";
             bool defaultCookieSecureValue = expectedCookieSecureFlag ?? false; // pulled from config; set by ctor
             var cookies = new MockResponseCookieCollection();
 
@@ -358,32 +279,19 @@ namespace Microsoft.AspNetCore.Antiforgery.Internal
                 .Setup(o => o.Response.Cookies)
                 .Returns(cookies);
 
-            var contextAccessor = new DefaultAntiforgeryContextAccessor();
-            mockHttpContext
-                .SetupGet(o => o.RequestServices)
-                .Returns(GetServiceProvider(contextAccessor));
-
-            var mockSerializer = new Mock<IAntiforgeryTokenSerializer>();
-            mockSerializer
-                .Setup(o => o.Serialize(token))
-                .Returns("serialized-value");
-
             var options = new AntiforgeryOptions()
             {
                 CookieName = _cookieName,
                 RequireSsl = requireSsl
             };
 
-            var tokenStore = new DefaultAntiforgeryTokenStore(
-                optionsAccessor: new TestOptionsManager(options),
-                tokenSerializer: mockSerializer.Object);
+            var tokenStore = new DefaultAntiforgeryTokenStore(new TestOptionsManager(options));
 
             // Act
             tokenStore.SaveCookieToken(mockHttpContext.Object, token);
 
             // Assert
             Assert.Equal(1, cookies.Count);
-            Assert.NotNull(contextAccessor.Value.CookieToken);
             Assert.NotNull(cookies);
             Assert.Equal(_cookieName, cookies.Key);
             Assert.Equal("serialized-value", cookies.Value);
@@ -391,37 +299,22 @@ namespace Microsoft.AspNetCore.Antiforgery.Internal
             Assert.Equal(defaultCookieSecureValue, cookies.Options.Secure);
         }
 
-        private HttpContext GetHttpContext(
-            string cookieName,
-            string cookieValue,
-            IAntiforgeryContextAccessor contextAccessor = null)
+        private HttpContext GetHttpContext(string cookieName, string cookieValue)
         {
             var cookies = new RequestCookieCollection(new Dictionary<string, string>
             {
                 { cookieName, cookieValue },
             });
 
-            return GetHttpContext(cookies, contextAccessor);
+            return GetHttpContext(cookies);
         }
 
-        private HttpContext GetHttpContext(
-            IRequestCookieCollection cookies,
-            IAntiforgeryContextAccessor contextAccessor = null)
+        private HttpContext GetHttpContext(IRequestCookieCollection cookies)
         {
             var httpContext = new DefaultHttpContext();
             httpContext.Request.Cookies = cookies;
 
-            contextAccessor = contextAccessor ?? new DefaultAntiforgeryContextAccessor();
-            httpContext.RequestServices = GetServiceProvider(contextAccessor);
-
             return httpContext;
-        }
-
-        private static IServiceProvider GetServiceProvider(IAntiforgeryContextAccessor contextAccessor)
-        {
-            var serviceCollection = new ServiceCollection();
-            serviceCollection.AddSingleton(contextAccessor);
-            return serviceCollection.BuildServiceProvider();
         }
 
         private class MockResponseCookieCollection : IResponseCookies

--- a/test/Microsoft.AspNetCore.Antiforgery.Test/Internal/DefaultAntiforgeryTokenStoreTest.cs
+++ b/test/Microsoft.AspNetCore.Antiforgery.Test/Internal/DefaultAntiforgeryTokenStoreTest.cs
@@ -6,8 +6,6 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Internal;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.ObjectPool;
 using Microsoft.Extensions.Primitives;
 using Moq;
 using Xunit;
@@ -16,8 +14,6 @@ namespace Microsoft.AspNetCore.Antiforgery.Internal
 {
     public class DefaultAntiforgeryTokenStoreTest
     {
-        private static readonly ObjectPool<AntiforgerySerializationContext> _pool =
-            new DefaultObjectPoolProvider().Create(new AntiforgerySerializationContextPooledObjectPolicy());
         private readonly string _cookieName = "cookie-name";
 
         [Fact]


### PR DESCRIPTION
- #23 part 3
- `Get[AndStore]Tokens()` would deserialize cookie token from request even if `IsRequestValidAsync()` already had
- `GetAndStoreTokens()` serialized an old (never saved) cookie token once and a new one twice

- refactor serialization from `DefaultAntiforgeryTokenStore` to `DefaultAntiforgery`
 - divide responsibilities and ease overall fix
- above refactoring took `IAntiforgeryContextAccessor` responsibilities along to `DefaultAntiforgery` as well
 - store all tokens in `IAntiforgeryContextAccessor` to avoid repeated (de)serializations
 - remove `AntiforgeryTokenSetInternal`

nit: bit more parameter renaming to `httpContext`