### PR TITLE
Make IsRequestValid check HTTP method

### DIFF
--- a/src/Microsoft.AspNetCore.Antiforgery/IAntiforgery.cs
+++ b/src/Microsoft.AspNetCore.Antiforgery/IAntiforgery.cs
@@ -36,12 +36,13 @@ namespace Microsoft.AspNetCore.Antiforgery
         AntiforgeryTokenSet GetTokens(HttpContext httpContext);
 
         /// <summary>
-        /// Asynchronously returns a value indicating whether the request contains a valid antiforgery token.
+        /// Asynchronously returns a value indicating whether the request passes antiforgery validation. If the
+        /// request uses a safe HTTP method (GET, HEAD, OPTIONS, TRACE), the antiforgery token is not validated.
         /// </summary>
         /// <param name="httpContext">The <see cref="HttpContext"/> associated with the current request.</param>
         /// <returns>
-        /// A <see cref="Task{bool}"/> that, when completed, returns <c>true</c> if the request contains a
-        /// valid antiforgery token, otherwise returns <c>false</c>.
+        /// A <see cref="Task{bool}"/> that, when completed, returns <c>true</c> if the is requst uses a safe HTTP
+        /// method or contains a value antiforgery token, otherwise returns <c>false</c>.
         /// </returns>
         Task<bool> IsRequestValidAsync(HttpContext httpContext);
 

--- a/src/Microsoft.AspNetCore.Antiforgery/Internal/DefaultAntiforgery.cs
+++ b/src/Microsoft.AspNetCore.Antiforgery/Internal/DefaultAntiforgery.cs
@@ -95,6 +95,16 @@ namespace Microsoft.AspNetCore.Antiforgery.Internal
 
             CheckSSLConfig(httpContext);
 
+            var method = httpContext.Request.Method;
+            if (string.Equals(method, "GET", StringComparison.OrdinalIgnoreCase) ||
+                string.Equals(method, "HEAD", StringComparison.OrdinalIgnoreCase) ||
+                string.Equals(method, "OPTIONS", StringComparison.OrdinalIgnoreCase) ||
+                string.Equals(method, "TRACE", StringComparison.OrdinalIgnoreCase))
+            {
+                // Validation not needed for these request types.
+                return true;
+            }
+
             var tokens = await _tokenStore.GetRequestTokensAsync(httpContext);
             if (tokens.CookieToken == null)
             {


### PR DESCRIPTION
This code was popping up everywhere this method is called. Seems bad to
duplicate it. Really what the caller wants to know is 'is the request
valid or a potential CSRF exploit?'. This gets the API closer to that.