### PR TITLE
Pool `char`s used for base64url-encoding and -decoding

### DIFF
--- a/src/Microsoft.AspNetCore.Antiforgery/Internal/DefaultAntiforgeryTokenSerializer.cs
+++ b/src/Microsoft.AspNetCore.Antiforgery/Internal/DefaultAntiforgeryTokenSerializer.cs
@@ -45,12 +45,16 @@ namespace Microsoft.AspNetCore.Antiforgery.Internal
                 var count = serializedToken.Length;
                 var charsRequired = WebEncoders.GetArraySizeRequiredToDecode(count);
                 var chars = serializationContext.GetChars(charsRequired);
-                serializedToken.CopyTo(0, chars, 0, count);
-                var tokenBytes = WebEncoders.Base64UrlDecode(chars, 0, count);
+                var tokenBytes = WebEncoders.Base64UrlDecode(
+                    serializedToken,
+                    offset: 0,
+                    count: count,
+                    buffer: chars,
+                    bufferOffset: 0);
 
                 var unprotectedBytes = _cryptoSystem.Unprotect(tokenBytes);
                 var stream = serializationContext.Stream;
-                stream.Write(unprotectedBytes, 0, unprotectedBytes.Length);
+                stream.Write(unprotectedBytes, offset: 0, count: unprotectedBytes.Length);
                 stream.Position = 0L;
 
                 var reader = serializationContext.Reader;
@@ -166,9 +170,14 @@ namespace Microsoft.AspNetCore.Antiforgery.Internal
                 var count = bytes.Length;
                 var charsRequired = WebEncoders.GetArraySizeRequiredToEncode(count);
                 var chars = serializationContext.GetChars(charsRequired);
-                var outputLength = WebEncoders.Base64UrlEncode(bytes, 0, count, chars, 0);
+                var outputLength = WebEncoders.Base64UrlEncode(
+                    bytes,
+                    offset: 0,
+                    count: count,
+                    output: chars,
+                    outputOffset: 0);
 
-                return new string(chars, 0, outputLength);
+                return new string(chars, startIndex: 0, length: outputLength);
             }
             finally
             {

--- a/src/Microsoft.AspNetCore.Antiforgery/Internal/DefaultAntiforgeryTokenSerializer.cs
+++ b/src/Microsoft.AspNetCore.Antiforgery/Internal/DefaultAntiforgeryTokenSerializer.cs
@@ -42,7 +42,12 @@ namespace Microsoft.AspNetCore.Antiforgery.Internal
             Exception innerException = null;
             try
             {
-                var tokenBytes = WebEncoders.Base64UrlDecode(serializedToken);
+                var count = serializedToken.Length;
+                var charsRequired = WebEncoders.GetArraySizeRequiredToDecode(count);
+                var chars = serializationContext.GetChars(charsRequired);
+                serializedToken.CopyTo(0, chars, 0, count);
+                var tokenBytes = WebEncoders.Base64UrlDecode(chars, 0, count);
+
                 var unprotectedBytes = _cryptoSystem.Unprotect(tokenBytes);
                 var stream = serializationContext.Stream;
                 stream.Write(unprotectedBytes, 0, unprotectedBytes.Length);
@@ -156,7 +161,14 @@ namespace Microsoft.AspNetCore.Antiforgery.Internal
 
                 writer.Flush();
                 var stream = serializationContext.Stream;
-                return WebEncoders.Base64UrlEncode(_cryptoSystem.Protect(stream.ToArray()));
+                var bytes = _cryptoSystem.Protect(stream.ToArray());
+
+                var count = bytes.Length;
+                var charsRequired = WebEncoders.GetArraySizeRequiredToEncode(count);
+                var chars = serializationContext.GetChars(charsRequired);
+                var outputLength = WebEncoders.Base64UrlEncode(bytes, 0, count, chars, 0);
+
+                return new string(chars, 0, outputLength);
             }
             finally
             {


### PR DESCRIPTION
- #23 part 4
- depends on aspnet/HttpAbstractions#563

nits:
- correct name of a field in `AntiforgerySerializationContext`
- avoid allocations when returning an `AntiforgerySerializationContext` in (unlikely) case `Stream` is unused