### PR TITLE
Preserve X-Frame-Options if it was already set

### DIFF
--- a/src/Microsoft.AspNetCore.Antiforgery/Internal/DefaultAntiforgery.cs
+++ b/src/Microsoft.AspNetCore.Antiforgery/Internal/DefaultAntiforgery.cs
@@ -248,7 +248,7 @@ namespace Microsoft.AspNetCore.Antiforgery.Internal
                 _tokenStore.SaveCookieToken(httpContext, cookieToken);
             }
 
-            if (!_options.SuppressXFrameOptionsHeader)
+            if (!_options.SuppressXFrameOptionsHeader && !httpContext.Response.Headers.ContainsKey("X-Frame-Options"))
             {
                 // Adding X-Frame-Options header to prevent ClickJacking. See
                 // http://tools.ietf.org/html/draft-ietf-websec-x-frame-options-10

--- a/test/Microsoft.AspNetCore.Antiforgery.Test/Internal/DefaultAntiforgeryTest.cs
+++ b/test/Microsoft.AspNetCore.Antiforgery.Test/Internal/DefaultAntiforgeryTest.cs
@@ -783,6 +783,31 @@ namespace Microsoft.AspNetCore.Antiforgery.Internal
                 Times.Never);
         }
 
+        [Fact]
+        public void SetCookieTokenAndHeader_PreserveXFrameOptionsHeader()
+        {
+            // Arrange
+            var options = new AntiforgeryOptions();
+            var antiforgeryFeature = new AntiforgeryFeature();
+            var expectedHeaderValue = "DIFFERENTORIGIN";
+
+            // Generate a new cookie.
+            var context = CreateMockContext(
+                options,
+                useOldCookie: false,
+                isOldCookieValid: false,
+                antiforgeryFeature: antiforgeryFeature);
+            var antiforgery = GetAntiforgery(context);
+            context.HttpContext.Response.Headers["X-Frame-Options"] = expectedHeaderValue;
+
+            // Act
+            antiforgery.SetCookieTokenAndHeader(context.HttpContext);
+
+            // Assert
+            var xFrameOptions = context.HttpContext.Response.Headers["X-Frame-Options"];
+            Assert.Equal(expectedHeaderValue, xFrameOptions);
+        }
+
         [Theory]
         [InlineData(false, "SAMEORIGIN")]
         [InlineData(true, null)]


### PR DESCRIPTION
Fixes #60.

As per @rynowak and @Eilon's comments, we're now preserving the `X-Frame-Options` header in the response if it's already been set.