### PR TITLE
Use Angular lib instead of angular map file in sample

### DIFF
--- a/samples/AntiforgerySample/wwwroot/Index.html
+++ b/samples/AntiforgerySample/wwwroot/Index.html
@@ -38,7 +38,7 @@
             </form>
         </div>
     </div>
-    <script src="//code.angularjs.org/1.4.8/angular.min.js.map"></script>
+    <script src="//code.angularjs.org/1.4.8/angular.min.js"></script>
     <script src="app.js"></script>
     <script src="services.js"></script>
     <script src="controllers.js"></script>


### PR DESCRIPTION
A reference to angular did not exist and so the sample app would error with a message to that effect.