### PR TITLE
Fix antiforgery cookie from being set to empty pathbase

### DIFF
--- a/src/Microsoft.AspNetCore.Antiforgery/Internal/DefaultAntiforgeryTokenStore.cs
+++ b/src/Microsoft.AspNetCore.Antiforgery/Internal/DefaultAntiforgeryTokenStore.cs
@@ -71,7 +71,7 @@ namespace Microsoft.AspNetCore.Antiforgery.Internal
 
             var options = new CookieOptions();
             options.HttpOnly = true;
-            options.Path = _options.CookiePath ?? httpContext.Request.PathBase;
+            options.Path = _options.CookiePath ?? GetPathBase(httpContext);
             options.Domain = _options.CookieDomain;
             // Note: don't use "newCookie.Secure = _options.RequireSSL;" since the default
             // value of newCookie.Secure is populated out of band.
@@ -81,6 +81,16 @@ namespace Microsoft.AspNetCore.Antiforgery.Internal
             }
 
             httpContext.Response.Cookies.Append(_options.CookieName, token, options);
+        }
+
+        private string GetPathBase(HttpContext httpContext)
+        {
+            var pathBase = httpContext.Request.PathBase.ToString();
+            if (string.IsNullOrEmpty(pathBase))
+            {
+                pathBase = "/";
+            }
+            return pathBase;
         }
     }
 }

--- a/test/Microsoft.AspNetCore.Antiforgery.Test/Internal/DefaultAntiforgeryTokenStoreTest.cs
+++ b/test/Microsoft.AspNetCore.Antiforgery.Test/Internal/DefaultAntiforgeryTokenStoreTest.cs
@@ -274,10 +274,12 @@ namespace Microsoft.AspNetCore.Antiforgery.Internal
         }
 
         [Theory]
-        [InlineData("/")]
-        [InlineData("/vdir1")]
-        [InlineData("/vdir1/vdir2")]
-        public void SaveCookieToken_SetsCookieWithApproriatePathBase(string requestPathBase)
+        [InlineData(null, "/")]
+        [InlineData("", "/")]
+        [InlineData("/", "/")]
+        [InlineData("/vdir1", "/vdir1")]
+        [InlineData("/vdir1/vdir2", "/vdir1/vdir2")]
+        public void SaveCookieToken_SetsCookieWithApproriatePathBase(string requestPathBase, string expectedCookiePath)
         {
             // Arrange
             var token = "serialized-value";
@@ -305,7 +307,7 @@ namespace Microsoft.AspNetCore.Antiforgery.Internal
             Assert.Equal(_cookieName, cookies.Key);
             Assert.Equal("serialized-value", cookies.Value);
             Assert.True(cookies.Options.HttpOnly);
-            Assert.Equal(requestPathBase, cookies.Options.Path);
+            Assert.Equal(expectedCookiePath, cookies.Options.Path);
         }
 
         [Fact]


### PR DESCRIPTION
@Eilon @pranavkm @dougbu 

This is a similar issue as @DamianEdwards found here: https://github.com/aspnet/Mvc/issues/5512