### PR TITLE
Bump test projects up to .NET 4.5.2

### DIFF
--- a/test/Microsoft.AspNetCore.Antiforgery.Test/Internal/DefaultClaimUidExtractorTest.cs
+++ b/test/Microsoft.AspNetCore.Antiforgery.Test/Internal/DefaultClaimUidExtractorTest.cs
@@ -60,7 +60,7 @@ namespace Microsoft.AspNetCore.Antiforgery.Internal
             identity.AddClaim(new Claim(ClaimTypes.Email, "someone@antifrogery.com"));
             identity.AddClaim(new Claim(ClaimTypes.GivenName, "some"));
             identity.AddClaim(new Claim(ClaimTypes.Surname, "one"));
-#if NET451
+#if NET452
             // CoreCLR doesn't support an 'empty' name
             identity.AddClaim(new Claim(ClaimTypes.NameIdentifier, string.Empty));
 #endif

--- a/test/Microsoft.AspNetCore.Antiforgery.Test/Microsoft.AspNetCore.Antiforgery.Test.csproj
+++ b/test/Microsoft.AspNetCore.Antiforgery.Test/Microsoft.AspNetCore.Antiforgery.Test.csproj
@@ -3,7 +3,8 @@
   <Import Project="..\..\build\common.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp1.1;net451</TargetFrameworks>
+    <TargetFrameworks>netcoreapp1.1;net452</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netcoreapp1.1</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
- aspnet/Testing#248
- xUnit no longer supports .NET 4.5.1
- build tests for desktop .NET only on Windows