### PR TITLE
Fixed typo in IAntiforgery file

### DIFF
--- a/src/Microsoft.AspNetCore.Antiforgery/IAntiforgery.cs
+++ b/src/Microsoft.AspNetCore.Antiforgery/IAntiforgery.cs
@@ -41,7 +41,7 @@ namespace Microsoft.AspNetCore.Antiforgery
         /// </summary>
         /// <param name="httpContext">The <see cref="HttpContext"/> associated with the current request.</param>
         /// <returns>
-        /// A <see cref="Task{Boolean}"/> that, when completed, returns <c>true</c> if the is requst uses a safe HTTP
+        /// A <see cref="Task{Boolean}"/> that, when completed, returns <c>true</c> if the request uses a safe HTTP
         /// method or contains a value antiforgery token, otherwise returns <c>false</c>.
         /// </returns>
         Task<bool> IsRequestValidAsync(HttpContext httpContext);

--- a/src/Microsoft.AspNetCore.Antiforgery/IAntiforgery.cs
+++ b/src/Microsoft.AspNetCore.Antiforgery/IAntiforgery.cs
@@ -42,7 +42,7 @@ namespace Microsoft.AspNetCore.Antiforgery
         /// <param name="httpContext">The <see cref="HttpContext"/> associated with the current request.</param>
         /// <returns>
         /// A <see cref="Task{Boolean}"/> that, when completed, returns <c>true</c> if the request uses a safe HTTP
-        /// method or contains a value antiforgery token, otherwise returns <c>false</c>.
+        /// method or contains a valid antiforgery token, otherwise returns <c>false</c>.
         /// </returns>
         Task<bool> IsRequestValidAsync(HttpContext httpContext);
 


### PR DESCRIPTION
Removed the `is` word, and changed `requst` to `request` on line 44.