### PR TITLE
React to parser StringSegment changes

### DIFF
--- a/src/Microsoft.AspNetCore.Antiforgery/Internal/DefaultAntiforgery.cs
+++ b/src/Microsoft.AspNetCore.Antiforgery/Internal/DefaultAntiforgery.cs
@@ -384,7 +384,7 @@ namespace Microsoft.AspNetCore.Antiforgery.Internal
         {
             var logWarning = false;
             CacheControlHeaderValue cacheControlHeaderValue;
-            if (CacheControlHeaderValue.TryParse(response.Headers[HeaderNames.CacheControl], out cacheControlHeaderValue))
+            if (CacheControlHeaderValue.TryParse(response.Headers[HeaderNames.CacheControl].ToString(), out cacheControlHeaderValue))
             {
                 if (!cacheControlHeaderValue.NoCache)
                 {


### PR DESCRIPTION
https://github.com/aspnet/HttpAbstractions/pull/844
There's an implicit converter from StringValues to string, but it doesn't work transitively with the converter from string to StringSegment. This is probably for the best because the StringValues to string converter may do string concats that we want to be aware of in a perf sensitive context.