### PR TITLE
Make SHA256 algorithm creation FIPS compliant.

### DIFF
--- a/src/Microsoft.AspNetCore.Antiforgery/Internal/AntiforgeryOptionsSetup.cs
+++ b/src/Microsoft.AspNetCore.Antiforgery/Internal/AntiforgeryOptionsSetup.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Linq;
-using System.Security.Cryptography;
 using System.Text;
 using Microsoft.AspNetCore.DataProtection;
 using Microsoft.AspNetCore.WebUtilities;
@@ -28,7 +27,7 @@ namespace Microsoft.AspNetCore.Antiforgery.Internal
 
         private static string ComputeCookieName(string applicationId)
         {
-            using (var sha256 = SHA256.Create())
+            using (var sha256 = CryptographyAlgorithms.CreateSHA256())
             {
                 var hash = sha256.ComputeHash(Encoding.UTF8.GetBytes(applicationId));
                 var subHash = hash.Take(8).ToArray();

--- a/src/Microsoft.AspNetCore.Antiforgery/Internal/AntiforgerySerializationContext.cs
+++ b/src/Microsoft.AspNetCore.Antiforgery/Internal/AntiforgerySerializationContext.cs
@@ -88,7 +88,7 @@ namespace Microsoft.AspNetCore.Antiforgery.Internal
             {
                 if (_sha256 == null)
                 {
-                    _sha256 = SHA256.Create();
+                    _sha256 = CryptographyAlgorithms.CreateSHA256();
                 }
 
                 return _sha256;

--- a/src/Microsoft.AspNetCore.Antiforgery/Internal/CryptographyAlgorithms.cs
+++ b/src/Microsoft.AspNetCore.Antiforgery/Internal/CryptographyAlgorithms.cs
@@ -1,0 +1,25 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Security.Cryptography;
+
+namespace Microsoft.AspNetCore.Antiforgery.Internal
+{
+    public static class CryptographyAlgorithms
+    {
+        public static SHA256 CreateSHA256()
+        {
+            try
+            {
+                return SHA256.Create();
+            }
+            // SHA256.Create is documented to throw this exception on FIPS compliant machines.
+            // See: https://msdn.microsoft.com/en-us/library/z08hz7ad%28v=vs.110%29.aspx?f=255&MSPPError=-2147217396
+            catch (System.Reflection.TargetInvocationException)
+            {
+                // Fallback to a FIPS compliant SHA256 algorithm.
+                return new SHA256CryptoServiceProvider();
+            }
+        }
+    }
+}


### PR DESCRIPTION
- Tested this on a Windows 8.1 FIPS compliant machine with a net461 targeted application with/without my fix.

#144 
