### PR TITLE
Throwing AntiforgeryValidationException for failure to deserializing …

### DIFF
--- a/src/Microsoft.AspNetCore.Antiforgery/AntiforgeryValidationException.cs
+++ b/src/Microsoft.AspNetCore.Antiforgery/AntiforgeryValidationException.cs
@@ -12,11 +12,22 @@ namespace Microsoft.AspNetCore.Antiforgery
     {
         /// <summary>
         /// Creates a new instance of <see cref="AntiforgeryValidationException"/> with the specified
-        /// exception <paramref name="message"/>.
+        /// exception message.
         /// </summary>
         /// <param name="message">The message that describes the error.</param>
         public AntiforgeryValidationException(string message)
             : base(message)
+        {
+        }
+
+        /// <summary>
+        /// Creates a new instance of <see cref="AntiforgeryValidationException"/> with the specified
+        /// exception message and inner exception.
+        /// </summary>
+        /// <param name="message">The message that describes the error.</param>
+        /// <param name="innerException">The inner <see cref="Exception"/>.</param>
+        public AntiforgeryValidationException(string message, Exception innerException)
+            : base(message, innerException)
         {
         }
     }

--- a/src/Microsoft.AspNetCore.Antiforgery/Internal/AntiforgeryLoggerExtensions.cs
+++ b/src/Microsoft.AspNetCore.Antiforgery/Internal/AntiforgeryLoggerExtensions.cs
@@ -8,6 +8,7 @@ namespace Microsoft.AspNetCore.Antiforgery.Internal
 {
     internal static class AntiforgeryLoggerExtensions
     {
+        private static readonly Action<ILogger, Exception> _failedToDeserialzeTokens;
         private static readonly Action<ILogger, string, Exception> _validationFailed;
         private static readonly Action<ILogger, Exception> _validated;
         private static readonly Action<ILogger, string, Exception> _missingCookieToken;
@@ -54,6 +55,10 @@ namespace Microsoft.AspNetCore.Antiforgery.Internal
                  "The 'Cache-Control' and 'Pragma' headers have been overridden and set to 'no-cache, no-store' and " +
                 "'no-cache' respectively to prevent caching of this response. Any response that uses antiforgery " +
                 "should not be cached.");
+            _failedToDeserialzeTokens = LoggerMessage.Define(
+                LogLevel.Debug,
+                9,
+                "Failed to deserialize antiforgery tokens.");
         }
 
         public static void ValidationFailed(this ILogger logger, string message)
@@ -94,6 +99,11 @@ namespace Microsoft.AspNetCore.Antiforgery.Internal
         public static void ResponseCacheHeadersOverridenToNoCache(this ILogger logger)
         {
             _responseCacheHeadersOverridenToNoCache(logger, null);
+        }
+
+        public static void FailedToDeserialzeTokens(this ILogger logger, Exception exception)
+        {
+            _failedToDeserialzeTokens(logger, exception);
         }
     }
 }

--- a/src/Microsoft.AspNetCore.Antiforgery/Internal/DefaultAntiforgeryTokenSerializer.cs
+++ b/src/Microsoft.AspNetCore.Antiforgery/Internal/DefaultAntiforgeryTokenSerializer.cs
@@ -75,7 +75,7 @@ namespace Microsoft.AspNetCore.Antiforgery.Internal
             }
 
             // if we reached this point, something went wrong deserializing
-            throw new InvalidOperationException(Resources.AntiforgeryToken_DeserializationFailed, innerException);
+            throw new AntiforgeryValidationException(Resources.AntiforgeryToken_DeserializationFailed, innerException);
         }
 
         /* The serialized format of the anti-XSRF token is as follows:

--- a/test/Microsoft.AspNetCore.Antiforgery.Test/Internal/DefaultAntiforgeryTokenSerializerTest.cs
+++ b/test/Microsoft.AspNetCore.Antiforgery.Test/Internal/DefaultAntiforgeryTokenSerializerTest.cs
@@ -51,7 +51,7 @@ namespace Microsoft.AspNetCore.Antiforgery.Internal
             var testSerializer = new DefaultAntiforgeryTokenSerializer(_dataProtector.Object, _pool);
 
             // Act & assert
-            var ex = Assert.Throws<InvalidOperationException>(() => testSerializer.Deserialize(serializedToken));
+            var ex = Assert.Throws<AntiforgeryValidationException>(() => testSerializer.Deserialize(serializedToken));
             Assert.Equal(@"The antiforgery token could not be decrypted.", ex.Message);
         }
 


### PR DESCRIPTION
…tokens

Related to https://github.com/aspnet/Home/issues/2410 : Tampered antiforgery token should not result in InvalidOperationException
  
For reference: https://github.com/aspnet/Mvc/blob/dev/src/Microsoft.AspNetCore.Mvc.ViewFeatures/Internal/ValidateAntiforgeryTokenAuthorizationFilter.cs#L45