### PR TITLE
Updated the DefaultAntiforgery to set the the cache headers only if…

### DIFF
--- a/src/Microsoft.AspNetCore.Antiforgery/Internal/DefaultAntiforgery.cs
+++ b/src/Microsoft.AspNetCore.Antiforgery/Internal/DefaultAntiforgery.cs
@@ -24,11 +24,11 @@ namespace Microsoft.AspNetCore.Antiforgery.Internal
         private readonly ILogger<DefaultAntiforgery> _logger;
 
         public DefaultAntiforgery(
-                    IOptions<AntiforgeryOptions> antiforgeryOptionsAccessor,
-                    IAntiforgeryTokenGenerator tokenGenerator,
-                    IAntiforgeryTokenSerializer tokenSerializer,
-                    IAntiforgeryTokenStore tokenStore,
-                    ILoggerFactory loggerFactory)
+            IOptions<AntiforgeryOptions> antiforgeryOptionsAccessor,
+            IAntiforgeryTokenGenerator tokenGenerator,
+            IAntiforgeryTokenSerializer tokenSerializer,
+            IAntiforgeryTokenStore tokenStore,
+            ILoggerFactory loggerFactory)
         {
             _options = antiforgeryOptionsAccessor.Value;
             _tokenGenerator = tokenGenerator;

--- a/src/Microsoft.AspNetCore.Antiforgery/Internal/DefaultAntiforgery.cs
+++ b/src/Microsoft.AspNetCore.Antiforgery/Internal/DefaultAntiforgery.cs
@@ -380,13 +380,13 @@ namespace Microsoft.AspNetCore.Antiforgery.Internal
         /// <param name="httpContext">The <see cref="HttpContext"/>.</param>
         protected virtual void SetDoNotCacheHeaders(HttpContext httpContext)
         {
-                // Since antifogery token generation is not very obvious to the end users (ex: MVC's form tag generates them
-                // by default), log a warning to let users know of the change in behavior to any cache headers they might
-                // have set explicitly.
-                LogCacheHeaderOverrideWarning(httpContext.Response);
+            // Since antifogery token generation is not very obvious to the end users (ex: MVC's form tag generates them
+            // by default), log a warning to let users know of the change in behavior to any cache headers they might
+            // have set explicitly.
+            LogCacheHeaderOverrideWarning(httpContext.Response);
 
-                httpContext.Response.Headers[HeaderNames.CacheControl] = "no-cache, no-store";
-                httpContext.Response.Headers[HeaderNames.Pragma] = "no-cache";
+            httpContext.Response.Headers[HeaderNames.CacheControl] = "no-cache, no-store";
+            httpContext.Response.Headers[HeaderNames.Pragma] = "no-cache";
         }
 
         private void LogCacheHeaderOverrideWarning(HttpResponse response)

--- a/test/Microsoft.AspNetCore.Antiforgery.Test/Internal/DefaultAntiforgeryTest.cs
+++ b/test/Microsoft.AspNetCore.Antiforgery.Test/Internal/DefaultAntiforgeryTest.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Security.Claims;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Features;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Testing;
@@ -1138,6 +1139,47 @@ namespace Microsoft.AspNetCore.Antiforgery.Internal
         }
 
         [Fact]
+        public void SetCookieTokenAndHeader_DoesNotModifyHeadersAfterResponseHasStarted()
+        {
+            // Arrange
+            var antiforgeryFeature = new AntiforgeryFeature
+            {
+                HaveDeserializedCookieToken = false,
+                HaveGeneratedNewCookieToken = false,
+                HaveStoredNewCookieToken = true,
+                NewCookieToken = new AntiforgeryToken(),
+                NewCookieTokenString = "serialized-cookie-token-from-context",
+                NewRequestToken = new AntiforgeryToken(),
+                NewRequestTokenString = "serialized-form-token-from-context",
+            };
+            var context = CreateMockContext(
+                new AntiforgeryOptions(),
+                useOldCookie: false,
+                isOldCookieValid: false,
+                antiforgeryFeature: antiforgeryFeature);
+            var testTokenSet = new TestTokenSet
+            {
+                OldCookieTokenString = null
+            };
+
+            var nullTokenStore = GetTokenStore(context.HttpContext, testTokenSet, false);
+            var antiforgery = GetAntiforgery(
+                context.HttpContext,
+                tokenGenerator: context.TokenGenerator.Object,
+                tokenStore: nullTokenStore.Object);
+
+            TestResponseFeature testResponse = new TestResponseFeature();
+            context.HttpContext.Features.Set<IHttpResponseFeature>(testResponse);
+            context.HttpContext.Response.Headers["Cache-Control"] = "public";
+            testResponse.StartResponse();
+
+            // Act
+            antiforgery.SetCookieTokenAndHeader(context.HttpContext);
+
+            Assert.Equal("public", context.HttpContext.Response.Headers["Cache-Control"]);
+        }
+
+        [Fact]
         public void GetAndStoreTokens_DoesNotLogWarning_IfNoExistingCacheHeadersPresent()
         {
             // Arrange
@@ -1196,6 +1238,7 @@ namespace Microsoft.AspNetCore.Antiforgery.Internal
             var antiforgery = GetAntiforgery(context);
             context.HttpContext.Response.Headers[headerName] = headerValue;
 
+            //context.HttpContext.Features
             // Act
             var tokenSet = antiforgery.GetAndStoreTokens(context.HttpContext);
 
@@ -1434,6 +1477,22 @@ namespace Microsoft.AspNetCore.Antiforgery.Internal
         private class TestOptionsManager : IOptions<AntiforgeryOptions>
         {
             public AntiforgeryOptions Value { get; set; } = new AntiforgeryOptions();
+        }
+
+        private class TestResponseFeature : HttpResponseFeature
+        {
+            private bool _hasStarted = false;
+
+            public override bool HasStarted { get => _hasStarted; }
+
+            public TestResponseFeature()
+            {
+            }
+
+            public void StartResponse()
+            {
+                _hasStarted = true;
+            }
         }
     }
 }

--- a/test/Microsoft.AspNetCore.Antiforgery.Test/Internal/DefaultAntiforgeryTest.cs
+++ b/test/Microsoft.AspNetCore.Antiforgery.Test/Internal/DefaultAntiforgeryTest.cs
@@ -1238,7 +1238,6 @@ namespace Microsoft.AspNetCore.Antiforgery.Internal
             var antiforgery = GetAntiforgery(context);
             context.HttpContext.Response.Headers[headerName] = headerValue;
 
-            //context.HttpContext.Features
             // Act
             var tokenSet = antiforgery.GetAndStoreTokens(context.HttpContext);
 


### PR DESCRIPTION
… they aren't set yet.

This was resulting in an exception when a razor view was trying to render a form, when the headers have already been set.